### PR TITLE
인가코드 및 토큰 발급 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,9 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	//json
+	implementation 'org.json:json:20210307'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/atm/bounded_context/auth/config/KakaoProperties.java
+++ b/src/main/java/com/example/atm/bounded_context/auth/config/KakaoProperties.java
@@ -18,5 +18,5 @@ public class KakaoProperties {
     private String clientSecret;
     private String adminKey;
     private String redirectUri;
-    private List<String> scope;
+    private String scope;
 }

--- a/src/main/java/com/example/atm/bounded_context/auth/config/KakaoProperties.java
+++ b/src/main/java/com/example/atm/bounded_context/auth/config/KakaoProperties.java
@@ -1,0 +1,22 @@
+package com.example.atm.bounded_context.auth.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+@Data
+@Configuration
+@ConfigurationProperties(prefix = "kakao")
+public class KakaoProperties {
+    private String authorizationUri;
+    private String tokenUri;
+    private String userInfoUri;
+    private String unlinkUri;
+    private String clientId;
+    private String clientSecret;
+    private String adminKey;
+    private String redirectUri;
+    private List<String> scope;
+}

--- a/src/main/java/com/example/atm/bounded_context/auth/config/KakaoProperties.java
+++ b/src/main/java/com/example/atm/bounded_context/auth/config/KakaoProperties.java
@@ -4,8 +4,6 @@ import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
-import java.util.List;
-
 @Data
 @Configuration
 @ConfigurationProperties(prefix = "kakao")

--- a/src/main/java/com/example/atm/bounded_context/auth/controller/AuthController.java
+++ b/src/main/java/com/example/atm/bounded_context/auth/controller/AuthController.java
@@ -22,10 +22,11 @@ public class AuthController {
      * 인증 코드 받기 요청 : 소셜 로그인으로 인가 코드를 받을 수 있는 링크로 리다이렉션 합니다.<br>
      * 인가 코드 받기 요청의 응답은 HTTP 302 리다이렉트되어, redirect_uri에 GET 요청으로 전달됩니다.<br>
      * https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api#request-code
+     *
      * @return uri
      */
     @GetMapping("/authorize")
-    public RedirectView authorize(){
+    public RedirectView authorize() {
         String uri = oAuthService.getAuthorizeUri();
         return new RedirectView(uri);
     }
@@ -34,12 +35,13 @@ public class AuthController {
      * 인가 코드 받기: 로그인 동의 화면을 호출하고, 사용자 동의를 거쳐 인가 코드를 발급합니다.<br>
      * 사용자가 모든 필수 동의항목에 동의하고 [동의하고 계속하기] 버튼을 누른 경우 : redirect_uri로 인가 코드를 담은 쿼리 스트링 전달됩니다.<br>
      * 사용자가 동의 화면에서 [취소] 버튼을 눌러 로그인을 취소한 경우 : redirect_uri로 에러 정보를 담은 쿼리 스트링 전달됩니다.<br>
+     *
      * @param code 인가 코드
      * @return TokenInfoDto 발급된 토큰
      * @throws HttpClientErrorException api 요청 실패 시 발생합니다.
      */
     @GetMapping("/token")
-    public ResponseEntity<TokenInfoDto> token(@RequestParam("code") String code){
+    public ResponseEntity<TokenInfoDto> token(@RequestParam("code") String code) {
         TokenInfoDto token = oAuthService.getToken(code);
         return ResponseEntity.ok().body(token);
     }

--- a/src/main/java/com/example/atm/bounded_context/auth/controller/AuthController.java
+++ b/src/main/java/com/example/atm/bounded_context/auth/controller/AuthController.java
@@ -1,0 +1,46 @@
+package com.example.atm.bounded_context.auth.controller;
+
+import com.example.atm.bounded_context.auth.dto.TokenInfoDto;
+import com.example.atm.bounded_context.auth.service.OAuthService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.servlet.view.RedirectView;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/auth")
+public class AuthController {
+
+    private final OAuthService oAuthService;
+
+    /**
+     * 인증 코드 받기 요청 : 소셜 로그인으로 인가 코드를 받을 수 있는 링크로 리다이렉션 합니다.<br>
+     * 인가 코드 받기 요청의 응답은 HTTP 302 리다이렉트되어, redirect_uri에 GET 요청으로 전달됩니다.<br>
+     * https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api#request-code
+     * @return uri
+     */
+    @GetMapping("/authorize")
+    public RedirectView authorize(){
+        String uri = oAuthService.getAuthorizeUri();
+        return new RedirectView(uri);
+    }
+
+    /**
+     * 인가 코드 받기: 로그인 동의 화면을 호출하고, 사용자 동의를 거쳐 인가 코드를 발급합니다.<br>
+     * 사용자가 모든 필수 동의항목에 동의하고 [동의하고 계속하기] 버튼을 누른 경우 : redirect_uri로 인가 코드를 담은 쿼리 스트링 전달됩니다.<br>
+     * 사용자가 동의 화면에서 [취소] 버튼을 눌러 로그인을 취소한 경우 : redirect_uri로 에러 정보를 담은 쿼리 스트링 전달됩니다.<br>
+     * @param code 인가 코드
+     * @return TokenInfoDto 발급된 토큰
+     * @throws HttpClientErrorException api 요청 실패 시 발생합니다.
+     */
+    @GetMapping("/token")
+    public ResponseEntity<TokenInfoDto> token(@RequestParam("code") String code){
+        TokenInfoDto token = oAuthService.getToken(code);
+        return ResponseEntity.ok().body(token);
+    }
+}

--- a/src/main/java/com/example/atm/bounded_context/auth/dto/TokenInfoDto.java
+++ b/src/main/java/com/example/atm/bounded_context/auth/dto/TokenInfoDto.java
@@ -4,8 +4,8 @@ public record TokenInfoDto(
         String accessToken,
         String refreshToken,
         String scope
-){
-    public static TokenInfoDto of(String accessToken, String refreshToken, String scope){
+) {
+    public static TokenInfoDto of(String accessToken, String refreshToken, String scope) {
         return new TokenInfoDto(accessToken, refreshToken, scope);
     }
 }

--- a/src/main/java/com/example/atm/bounded_context/auth/dto/TokenInfoDto.java
+++ b/src/main/java/com/example/atm/bounded_context/auth/dto/TokenInfoDto.java
@@ -1,0 +1,11 @@
+package com.example.atm.bounded_context.auth.dto;
+
+public record TokenInfoDto(
+        String accessToken,
+        String refreshToken,
+        String scope
+){
+    public static TokenInfoDto of(String accessToken, String refreshToken, String scope){
+        return new TokenInfoDto(accessToken, refreshToken, scope);
+    }
+}

--- a/src/main/java/com/example/atm/bounded_context/auth/dto/UserInfoDto.java
+++ b/src/main/java/com/example/atm/bounded_context/auth/dto/UserInfoDto.java
@@ -1,0 +1,12 @@
+package com.example.atm.bounded_context.auth.dto;
+
+public record UserInfoDto (
+        Long id,
+        String nickname,
+        String email,
+        String profileImageUrl
+){
+    public static UserInfoDto of(Long id, String nickname, String email, String profileImageUrl){
+        return new UserInfoDto(id, nickname, email, profileImageUrl);
+    }
+}

--- a/src/main/java/com/example/atm/bounded_context/auth/dto/UserInfoDto.java
+++ b/src/main/java/com/example/atm/bounded_context/auth/dto/UserInfoDto.java
@@ -1,12 +1,12 @@
 package com.example.atm.bounded_context.auth.dto;
 
-public record UserInfoDto (
+public record UserInfoDto(
         Long id,
         String nickname,
         String email,
         String profileImageUrl
-){
-    public static UserInfoDto of(Long id, String nickname, String email, String profileImageUrl){
+) {
+    public static UserInfoDto of(Long id, String nickname, String email, String profileImageUrl) {
         return new UserInfoDto(id, nickname, email, profileImageUrl);
     }
 }

--- a/src/main/java/com/example/atm/bounded_context/auth/service/KakaoOAuthService.java
+++ b/src/main/java/com/example/atm/bounded_context/auth/service/KakaoOAuthService.java
@@ -1,0 +1,65 @@
+package com.example.atm.bounded_context.auth.service;
+
+import com.example.atm.bounded_context.auth.config.KakaoProperties;
+import com.example.atm.bounded_context.auth.dto.TokenInfoDto;
+import com.example.atm.bounded_context.auth.dto.UserInfoDto;
+import lombok.RequiredArgsConstructor;
+import org.json.JSONObject;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+@RequiredArgsConstructor
+public class KakaoOAuthService implements OAuthService{
+
+    private final KakaoProperties kakaoProperties;
+
+    /**
+     * 토큰 받기 : 인가 코드로 토큰 발급을 요청합니다.<br>
+     * https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api#request-token
+     * @param code 인가 코드
+     * @return TokenInfoDto 발급된 토큰
+     * @throws HttpClientErrorException api 요청 실패 시 발생합니다.
+     */
+    @Override
+    public TokenInfoDto getToken(String code) {
+        RestTemplate restTemplate = new RestTemplate();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("grant_type", "authorization_code");
+        params.add("client_id", kakaoProperties.getClientId());
+        params.add("client_secret", kakaoProperties.getClientSecret());
+        params.add("redirect_uri", kakaoProperties.getRedirectUri());
+        params.add("code", code);
+
+        HttpEntity<MultiValueMap<String, String>> entity = new HttpEntity<>(params, headers);
+        ResponseEntity<String> response = restTemplate.postForEntity(kakaoProperties.getTokenUri(), entity, String.class);
+
+        JSONObject tokenInfoJson = new JSONObject(response.getBody());
+        String accessToken = tokenInfoJson.getString("access_token");
+        String refreshToken = tokenInfoJson.getString("refresh_token");
+        String scope = tokenInfoJson.getString("scope");
+
+        return TokenInfoDto.of(accessToken, refreshToken, scope);
+    }
+
+    @Override
+    public UserInfoDto getUserInfo(String accessToken) {
+        return null;
+    }
+
+    @Override
+    public void unlink(String socialId) {
+
+    }
+}

--- a/src/main/java/com/example/atm/bounded_context/auth/service/KakaoOAuthService.java
+++ b/src/main/java/com/example/atm/bounded_context/auth/service/KakaoOAuthService.java
@@ -5,7 +5,11 @@ import com.example.atm.bounded_context.auth.dto.TokenInfoDto;
 import com.example.atm.bounded_context.auth.dto.UserInfoDto;
 import lombok.RequiredArgsConstructor;
 import org.json.JSONObject;
-import org.springframework.http.*;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
@@ -15,12 +19,13 @@ import org.springframework.web.util.UriComponentsBuilder;
 
 @Service
 @RequiredArgsConstructor
-public class KakaoOAuthService implements OAuthService{
+public class KakaoOAuthService implements OAuthService {
 
     private final KakaoProperties kakaoProperties;
 
     /**
      * 인가 코드 요청 uri 생성 : 인가 코드를 요청하는 uri 를 생성하여 반환합니다.<br>
+     *
      * @return uri
      */
     @Override
@@ -36,6 +41,7 @@ public class KakaoOAuthService implements OAuthService{
     /**
      * 토큰 받기 : 인가 코드로 토큰 발급을 요청합니다.<br>
      * https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api#request-token
+     *
      * @param code 인가 코드
      * @return TokenInfoDto 토큰 정보
      * @throws HttpClientErrorException api 요청 실패 시 발생합니다.
@@ -68,6 +74,7 @@ public class KakaoOAuthService implements OAuthService{
     /**
      * 사용자 정보 받기 : 현재 로그인한 사용자의 정보를 불러옵니다.<br>
      * https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api#req-user-info
+     *
      * @param accessToken 소셜 인증 서버 access token
      * @return UserInfoDto 유저 정보
      * @throws HttpClientErrorException api 요청 실패 시 발생합니다.
@@ -85,8 +92,8 @@ public class KakaoOAuthService implements OAuthService{
         JSONObject userInfoJson = new JSONObject(response.getBody());
         Long id = userInfoJson.getLong("id");
         String email = userInfoJson.getJSONObject("kakao_account").getString("email");
-        String nickname = userInfoJson.getJSONObject("kakao_account").getJSONObject("profile").getString("nickname");;
-        String profileImageUrl = userInfoJson.getJSONObject("kakao_account").getJSONObject("profile").getString("profile_image_url");;
+        String nickname = userInfoJson.getJSONObject("kakao_account").getJSONObject("profile").getString("nickname");
+        String profileImageUrl = userInfoJson.getJSONObject("kakao_account").getJSONObject("profile").getString("profile_image_url");
 
         return UserInfoDto.of(id, nickname, email, profileImageUrl);
     }

--- a/src/main/java/com/example/atm/bounded_context/auth/service/KakaoOAuthService.java
+++ b/src/main/java/com/example/atm/bounded_context/auth/service/KakaoOAuthService.java
@@ -14,12 +14,27 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
 
 @Service
 @RequiredArgsConstructor
 public class KakaoOAuthService implements OAuthService{
 
     private final KakaoProperties kakaoProperties;
+
+    /**
+     * 인가 코드 요청 uri 생성 : 인가 코드를 요청하는 uri 를 생성하여 반환합니다.<br>
+     * @return uri
+     */
+    @Override
+    public String getAuthorizeUri() {
+        return UriComponentsBuilder.fromHttpUrl(kakaoProperties.getAuthorizationUri())
+                .queryParam("response_type", "code")
+                .queryParam("client_id", kakaoProperties.getClientId())
+                .queryParam("redirect_uri", kakaoProperties.getRedirectUri())
+                .queryParam("scope", kakaoProperties.getScope())
+                .toUriString();
+    }
 
     /**
      * 토큰 받기 : 인가 코드로 토큰 발급을 요청합니다.<br>

--- a/src/main/java/com/example/atm/bounded_context/auth/service/OAuthService.java
+++ b/src/main/java/com/example/atm/bounded_context/auth/service/OAuthService.java
@@ -5,7 +5,10 @@ import com.example.atm.bounded_context.auth.dto.UserInfoDto;
 
 public interface OAuthService {
     String getAuthorizeUri();
+
     TokenInfoDto getToken(String code);
+
     UserInfoDto getUserInfo(String accessToken);
+
     void unlink(String socialId);
 }

--- a/src/main/java/com/example/atm/bounded_context/auth/service/OAuthService.java
+++ b/src/main/java/com/example/atm/bounded_context/auth/service/OAuthService.java
@@ -1,0 +1,10 @@
+package com.example.atm.bounded_context.auth.service;
+
+import com.example.atm.bounded_context.auth.dto.TokenInfoDto;
+import com.example.atm.bounded_context.auth.dto.UserInfoDto;
+
+public interface OAuthService {
+    TokenInfoDto getToken(String code);
+    UserInfoDto getUserInfo(String accessToken);
+    void unlink(String socialId);
+}

--- a/src/main/java/com/example/atm/bounded_context/auth/service/OAuthService.java
+++ b/src/main/java/com/example/atm/bounded_context/auth/service/OAuthService.java
@@ -4,6 +4,7 @@ import com.example.atm.bounded_context.auth.dto.TokenInfoDto;
 import com.example.atm.bounded_context.auth.dto.UserInfoDto;
 
 public interface OAuthService {
+    String getAuthorizeUri();
     TokenInfoDto getToken(String code);
     UserInfoDto getUserInfo(String accessToken);
     void unlink(String socialId);


### PR DESCRIPTION
### 🚀 작업 동기 및 이슈
- 인증서버 access token을 발급 받을 수 있는 인증 플랫폼 인가 코드 및 토큰 발급 API 필요
- close: #11


### 🚧 변경 사항
인가 코드 및 토큰 발급 API 구현
- 서치 결과 시큐리티를 사용하는 방법과 API를 직접 생성하는 방법이 있었는데, 후자가 사용하기는 번거로워도 API를 입맛대로 구성하고 재사용할 수 있다는 장점이 있다고 생각했습니다. 구현시에는 각각의 플랫폼마다 반환하는 방식이 다르므로 인터페이스를 사용하도록 했습니다. 
- 애플리케이션과 연동된 소셜 인증 링크를 미리 제공해주고 redirect-url 엔드포인트만 구현할 수 있었지만, 소셜 인증 링크 구성에 client-id 와 같은 중요 정보가 들어가므로 인가 코드를 생성해주는 엔드포인트 접근 시에 토큰 발급까지 이어지는게 자연스럽다 생각했습니다.

### 🔖 관련 정보
<img width="400" alt="image" src="https://github.com/user-attachments/assets/8b831f6b-85b9-4921-96ca-ab4bd735d0fa">

[카카오 로그인](https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api#kakaologin)
1. 인가 코드 받기 : /auth/authorize 를 사용하여 인가 코드를 받을 수 있는 링크로 리다이렉션 하도록 하고, 인가 코드를 받는 API를 요청하여 로그인이 성공한 경우 redirect-url로 반홥니다. 
2. 토큰 받기 : redirect-url 로 반환되는 code 를 통해서 토큰을 발급 받습니다. /auth/token 이 redirect-url 이며 토큰을 발급 받는 API를 요청하게 됩니다.


### 🧪 테스트 결과
- `GET : {{ip}}/auth/authorize` 를 입력한 경우 소셜 로그인 페이지로 리다이렉트 됩니다.
<img width="500" alt="image" src="https://github.com/user-attachments/assets/d0642a9f-9a62-472a-b566-d0c3e4b791ef">
<img width="250" alt="image" src="https://github.com/user-attachments/assets/26bd6e21-0411-4709-ba5f-52a10cf4d76d">

- 필수 동의항목에 동의하고 로그인이 성공한 경우 토큰을 발급받습니다.
<img width="500" alt="image" src="https://github.com/user-attachments/assets/09780256-ddf1-4da4-8266-3549e587d2db">
