### PR TITLE
회원 탈퇴 API 구현

### DIFF
--- a/src/main/java/com/example/atm/bounded_context/auth/controller/AuthController.java
+++ b/src/main/java/com/example/atm/bounded_context/auth/controller/AuthController.java
@@ -7,9 +7,11 @@ import com.example.atm.bounded_context.auth.service.OAuthService;
 import com.example.atm.bounded_context.user.dto.UserInfoDto;
 import com.example.atm.bounded_context.user.entity.User;
 import com.example.atm.bounded_context.user.service.UserService;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -78,5 +80,26 @@ public class AuthController {
 
         UserInfoDto response = UserInfoDto.fromEntity(user);
         return ResponseEntity.ok().headers(headers).body(response);
+    }
+
+    /**
+     * 회원 탈퇴: 회원 아이디로 회원탈퇴를 진행합니다<br>
+     * 인증 서버의 아이디로 인증 서버와의 연결을 끊고 데이터베이스에 레코드를 지웁니다.
+     *
+     * @param userId 회원 아이디
+     * @return
+     * @throws HttpClientErrorException 연결 끊기 api 요청 실패 시 발생합니다.
+     * @throws IllegalArgumentException 회원이 조회되지 않는 경우 발생합니다.
+     */
+    @DeleteMapping("/withdrawal")
+    public ResponseEntity<String> withdrawal(HttpServletRequest request) {
+        String accessToken = jwtProvider.getToken(request);
+        String userId = jwtProvider.getUserId(accessToken);
+
+        User user = userService.read(Long.parseLong(userId));
+        oAuthService.unlink(user.getSocialId());
+        userService.delete(user);
+
+        return ResponseEntity.ok().body("회원 탈퇴에 성공했습니다.");
     }
 }

--- a/src/main/java/com/example/atm/bounded_context/auth/service/KakaoOAuthService.java
+++ b/src/main/java/com/example/atm/bounded_context/auth/service/KakaoOAuthService.java
@@ -98,8 +98,26 @@ public class KakaoOAuthService implements OAuthService {
         return OAuthUserInfoDto.of(id, nickname, email, profileImageUrl);
     }
 
+    /**
+     * 연결 끊기 : 앱과 사용자 카카오계정의 연결을 끊는 기능입니다.(서비스 앱 어드민 키 방식)<br>
+     * https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api#unlink-request-admin-key
+     *
+     * @param socialId
+     * @throws HttpClientErrorException api 요청 실패 시 발생합니다.
+     */
     @Override
-    public void unlink(String socialId) {
+    public void unlink(Long socialId) {
+        RestTemplate restTemplate = new RestTemplate();
 
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        headers.set("Authorization", "KakaoAK " + kakaoProperties.getAdminKey());
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("target_id_type", "user_id");
+        params.add("target_id", socialId.toString());
+
+        HttpEntity<MultiValueMap<String, String>> entity = new HttpEntity<>(params, headers);
+        restTemplate.postForEntity(kakaoProperties.getUnlinkUri(), entity, String.class);
     }
 }

--- a/src/main/java/com/example/atm/bounded_context/auth/service/OAuthService.java
+++ b/src/main/java/com/example/atm/bounded_context/auth/service/OAuthService.java
@@ -10,5 +10,5 @@ public interface OAuthService {
 
     OAuthUserInfoDto getUserInfo(String accessToken);
 
-    void unlink(String socialId);
+    void unlink(Long socialId);
 }

--- a/src/main/java/com/example/atm/bounded_context/user/service/UserService.java
+++ b/src/main/java/com/example/atm/bounded_context/user/service/UserService.java
@@ -30,4 +30,9 @@ public class UserService {
                 .map(entity -> entity.update(user.getNickname(), user.getProfileImgUrl(), user.getGender()))
                 .orElseGet(() -> userRepository.save(user));
     }
+
+    @Transactional
+    public void delete(User user) {
+        userRepository.delete(user);
+    }
 }


### PR DESCRIPTION
### 🚀 작업 동기 및 이슈

애플리케이션 회원 탈퇴 API 필요

- close: #19

### 🚧 변경 사항

회원 탈퇴 API 구현

- 로그인 시 발급받은 애플리케이션 access token을 통해서 사용자를 찾습니다. 사용자의 소셜아이디 속성으로 인증 서버의 연결 끊기 API를 사용하여 애플리케이션과 연결을 끊고 데이터베이스에서 사용자 레코드를 삭제합니다.

### 🔖 관련 정보

[카카오톡 연결 끊기 API](https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api#unlink)

- 인증 서버의 access token 으로 연결 끊기 API를 사용할 수 있으나 그럼 인증 서버의 access token 은 어디에 저장해두어야 하는지 의문이 들었습니다.
    1. 요청 헤더에 둔다면 애플리케이션의 access token 과 인증 서버 access token 을 구분할 수 있어야 하므로 둘 중 하나는 Authorization 필드에 위치하지 못할 것입니다. 
    2. 데이터베이스에 저장해둔다면 암호화가 필요할 것이고 저장공간 비용이 들 것입니다. 또한 JWT 를 사용하는 stateless(서버에서 상태를 관리하지 않음) 의 이점이 사라지게 됩니다.
    
- 따라서 사용자에게 소셜 아이디를 저장하게하고, 인증 서버의 어드민 키와 소셜 아이디를 사용하여 연결 끊기 API를 사용하도록 했습니다.

### 🧪 테스트 결과

`DELETE : {{ip}}/auth/widthdrawal`

<img width="1029" alt="image" src="https://github.com/user-attachments/assets/468b1323-8655-4b5b-bf43-7caea38242d3">