### PR TITLE
User 조회 및 짝꿍 설정 API 구현

### DIFF
--- a/src/main/java/com/example/atm/bounded_context/user/controller/UserController.java
+++ b/src/main/java/com/example/atm/bounded_context/user/controller/UserController.java
@@ -1,15 +1,95 @@
 package com.example.atm.bounded_context.user.controller;
 
+import com.example.atm.base.jwt.JwtProvider;
+import com.example.atm.bounded_context.user.dto.UserInfoDto;
+import com.example.atm.bounded_context.user.entity.User;
+import com.example.atm.bounded_context.user.service.UserService;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@RequiredArgsConstructor
 @RequestMapping("/user")
 public class UserController {
+
+    private final JwtProvider jwtProvider;
+    private final UserService userService;
+
     @GetMapping("")
-    public ResponseEntity<String> test(){
+    public ResponseEntity<String> test() {
         return ResponseEntity.ok().body("테스트 성공");
     }
+
+    /**
+     * 내 정보 조회 : 애플리케이션 access token(JWT) 로 사용자 정보를 조회합니다.
+     *
+     * @param request
+     * @return UserInfoDto
+     */
+    @GetMapping("/me")
+    ResponseEntity<UserInfoDto> read(HttpServletRequest request) {
+        String accessToken = jwtProvider.getToken(request);
+        String userId = jwtProvider.getUserId(accessToken);
+
+        User user = userService.read(Long.parseLong(userId));
+        UserInfoDto response = UserInfoDto.fromEntity(user);
+
+        return ResponseEntity.ok().body(response);
+    }
+
+    /**
+     * 사용자 정보 조회 : userId 로 사용자 정보를 조회합니다.
+     *
+     * @param userId
+     * @return
+     */
+    @GetMapping("/{userId}")
+    ResponseEntity<UserInfoDto> read(@PathVariable Long userId) {
+
+        User user = userService.read(userId);
+        UserInfoDto response = UserInfoDto.fromEntity(user);
+
+        return ResponseEntity.ok().body(response);
+    }
+
+    /**
+     * 짝궁 연결 : 로그인한 사용자와 userId의 관계를 짝꿍으로 연결합니다.
+     *
+     * @param request
+     * @param userId
+     * @return
+     */
+    @PostMapping("/connect/{userId}")
+    public ResponseEntity<String> connectMate(HttpServletRequest request, @PathVariable Long userId) {
+        String accessToken = jwtProvider.getToken(request);
+        String acceptUserId = jwtProvider.getUserId(accessToken);
+
+        userService.connectMate(Long.parseLong(acceptUserId), userId);
+
+        return ResponseEntity.ok().body("짝꿍 연결에 성공했습니다.");
+    }
+
+    /**
+     * 짝궁 해제 : 로그인한 사용자와 userId의 짝꿍 관계를 해제합니다.
+     *
+     * @param request
+     * @param userId
+     * @return
+     */
+    @PostMapping("/disconnect/{userId}")
+    public ResponseEntity<String> disconnectMate(HttpServletRequest request, @PathVariable Long userId) {
+        String accessToken = jwtProvider.getToken(request);
+        String acceptUserId = jwtProvider.getUserId(accessToken);
+
+        userService.disconnectMate(Long.parseLong(acceptUserId), userId);
+
+        return ResponseEntity.ok().body("짝꿍 해제에 성공했습니다.");
+    }
+
 }

--- a/src/main/java/com/example/atm/bounded_context/user/controller/UserController.java
+++ b/src/main/java/com/example/atm/bounded_context/user/controller/UserController.java
@@ -27,10 +27,10 @@ public class UserController {
     }
 
     /**
-     * 내 정보 조회 : 애플리케이션 access token(JWT) 로 사용자 정보를 조회합니다.
+     * 사용자 본인 정보 조회 : 사용자가 본인의 정보를 조회하기 위한 메서드입니다.
      *
      * @param request
-     * @return UserInfoDto
+     * @return UserInfoDto 사용자 정보
      */
     @GetMapping("/me")
     ResponseEntity<UserInfoDto> read(HttpServletRequest request) {
@@ -44,10 +44,10 @@ public class UserController {
     }
 
     /**
-     * 사용자 정보 조회 : userId 로 사용자 정보를 조회합니다.
+     * 사용자 정보 조회 : 사용자가 다른 사용자의 정보를 조회하기 위한 메서드입니다.
      *
-     * @param userId
-     * @return
+     * @param userId 대상 사용자 아이디
+     * @return UserInfoDto 사용자 정보
      */
     @GetMapping("/{userId}")
     ResponseEntity<UserInfoDto> read(@PathVariable Long userId) {
@@ -59,11 +59,14 @@ public class UserController {
     }
 
     /**
-     * 짝궁 연결 : 로그인한 사용자와 userId의 관계를 짝꿍으로 연결합니다.
+     * 짝궁 연결 : 사용자가 짝꿍을 연결하기 위한 메서드입니다.
      *
      * @param request
-     * @param socialId
+     * @param socialId 대상 사용자 소셜 아이디
      * @return
+     * @throws IllegalArgumentException 본인의 짝꿍이 이미 존재하는 경우 발생합니다.
+     * @throws IllegalArgumentException 짝꿍 대상자가 존재하지 않는 경우 발생합니다.
+     * @throws IllegalArgumentException 짝꿍 대상자의 짝꿍이 이미 존재하는 경우 발생합니다.
      */
     @PatchMapping("/connect/{socialId}")
     public ResponseEntity<String> connectMate(HttpServletRequest request, @PathVariable Long socialId) {
@@ -76,10 +79,11 @@ public class UserController {
     }
 
     /**
-     * 짝궁 해제 : 로그인한 사용자와 userId의 짝꿍 관계를 해제합니다.
+     * 짝궁 해제 : 사용자의 짝꿍을 해제하기위한 메서드입니다.
      *
      * @param request
      * @return
+     * @throws IllegalArgumentException 본인의 짝꿍이 존재하지 않는 경우 발생합니다.
      */
     @PatchMapping("/disconnect")
     public ResponseEntity<String> disconnectMate(HttpServletRequest request) {

--- a/src/main/java/com/example/atm/bounded_context/user/controller/UserController.java
+++ b/src/main/java/com/example/atm/bounded_context/user/controller/UserController.java
@@ -8,8 +8,8 @@ import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -65,7 +65,7 @@ public class UserController {
      * @param socialId
      * @return
      */
-    @PostMapping("/connect/{socialId}")
+    @PatchMapping("/connect/{socialId}")
     public ResponseEntity<String> connectMate(HttpServletRequest request, @PathVariable Long socialId) {
         String accessToken = jwtProvider.getToken(request);
         String userId = jwtProvider.getUserId(accessToken);
@@ -79,15 +79,14 @@ public class UserController {
      * 짝궁 해제 : 로그인한 사용자와 userId의 짝꿍 관계를 해제합니다.
      *
      * @param request
-     * @param userId
      * @return
      */
-    @PostMapping("/disconnect/{userId}")
-    public ResponseEntity<String> disconnectMate(HttpServletRequest request, @PathVariable Long userId) {
+    @PatchMapping("/disconnect")
+    public ResponseEntity<String> disconnectMate(HttpServletRequest request) {
         String accessToken = jwtProvider.getToken(request);
         String acceptUserId = jwtProvider.getUserId(accessToken);
 
-        userService.disconnectMate(Long.parseLong(acceptUserId), userId);
+        userService.disconnectMate(Long.parseLong(acceptUserId));
 
         return ResponseEntity.ok().body("짝꿍 해제에 성공했습니다.");
     }

--- a/src/main/java/com/example/atm/bounded_context/user/controller/UserController.java
+++ b/src/main/java/com/example/atm/bounded_context/user/controller/UserController.java
@@ -62,15 +62,15 @@ public class UserController {
      * 짝궁 연결 : 로그인한 사용자와 userId의 관계를 짝꿍으로 연결합니다.
      *
      * @param request
-     * @param userId
+     * @param socialId
      * @return
      */
-    @PostMapping("/connect/{userId}")
-    public ResponseEntity<String> connectMate(HttpServletRequest request, @PathVariable Long userId) {
+    @PostMapping("/connect/{socialId}")
+    public ResponseEntity<String> connectMate(HttpServletRequest request, @PathVariable Long socialId) {
         String accessToken = jwtProvider.getToken(request);
-        String acceptUserId = jwtProvider.getUserId(accessToken);
+        String userId = jwtProvider.getUserId(accessToken);
 
-        userService.connectMate(Long.parseLong(acceptUserId), userId);
+        userService.connectMate(Long.parseLong(userId), socialId);
 
         return ResponseEntity.ok().body("짝꿍 연결에 성공했습니다.");
     }

--- a/src/main/java/com/example/atm/bounded_context/user/controller/UserController.java
+++ b/src/main/java/com/example/atm/bounded_context/user/controller/UserController.java
@@ -43,20 +43,20 @@ public class UserController {
         return ResponseEntity.ok().body(response);
     }
 
-    /**
-     * 사용자 정보 조회 : 사용자가 다른 사용자의 정보를 조회하기 위한 메서드입니다.
-     *
-     * @param userId 대상 사용자 아이디
-     * @return UserInfoDto 사용자 정보
-     */
-    @GetMapping("/{userId}")
-    ResponseEntity<UserInfoDto> read(@PathVariable Long userId) {
-
-        User user = userService.read(userId);
-        UserInfoDto response = UserInfoDto.fromEntity(user);
-
-        return ResponseEntity.ok().body(response);
-    }
+//    /**
+//     * 사용자 정보 조회 : 사용자가 다른 사용자의 정보를 조회하기 위한 메서드입니다.
+//     *
+//     * @param userId 대상 사용자 아이디
+//     * @return UserInfoDto 사용자 정보
+//     */
+//    @GetMapping("/{userId}")
+//    ResponseEntity<UserInfoDto> read(@PathVariable Long userId) {
+//
+//        User user = userService.read(userId);
+//        UserInfoDto response = UserInfoDto.fromEntity(user);
+//
+//        return ResponseEntity.ok().body(response);
+//    }
 
     /**
      * 짝궁 연결 : 사용자가 짝꿍을 연결하기 위한 메서드입니다.

--- a/src/main/java/com/example/atm/bounded_context/user/dto/UserInfoDto.java
+++ b/src/main/java/com/example/atm/bounded_context/user/dto/UserInfoDto.java
@@ -3,6 +3,8 @@ package com.example.atm.bounded_context.user.dto;
 import com.example.atm.bounded_context.user.entity.Gender;
 import com.example.atm.bounded_context.user.entity.User;
 
+import java.util.Optional;
+
 public record UserInfoDto(
         Long id,
         String email,
@@ -10,7 +12,8 @@ public record UserInfoDto(
         String profileImgUrl,
         Gender gender,
         Integer point,
-        Long socialId
+        Long socialId,
+        Long mateId
 ) {
     public static UserInfoDto fromEntity(User user) {
         return new UserInfoDto(
@@ -20,6 +23,10 @@ public record UserInfoDto(
                 user.getProfileImgUrl(),
                 user.getGender(),
                 user.getPoint(),
-                user.getSocialId());
+                user.getSocialId(),
+                Optional.ofNullable(user.getMate())
+                        .map(User::getId)
+                        .orElse(null)
+        );
     }
 }

--- a/src/main/java/com/example/atm/bounded_context/user/entity/User.java
+++ b/src/main/java/com/example/atm/bounded_context/user/entity/User.java
@@ -4,10 +4,12 @@ import com.example.atm.bounded_context.auth.dto.OAuthUserInfoDto;
 import com.example.atm.bounded_context.schedule.entity.Schedule;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -25,7 +27,7 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User implements UserDetails {
 
-    @OneToMany(mappedBy = "user")
+    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY)
     List<Schedule> schedules = new ArrayList<>();
 
     @Id
@@ -48,6 +50,9 @@ public class User implements UserDetails {
     private Integer point;
 
     private Long socialId;
+
+    @OneToOne
+    private User mate;
 
     @Builder
     public User(String email, String password, String nickname, String profileImgUrl, Gender gender, Integer point, Long socialId) {
@@ -74,6 +79,16 @@ public class User implements UserDetails {
         this.profileImgUrl = profileImgUrl;
         this.gender = gender;
         return this;
+    }
+
+    public void connectMate(User user) {
+        this.mate = user;
+        user.mate = this;
+    }
+
+    public void disconnectMate(User user) {
+        this.mate = null;
+        user.mate = null;
     }
 
     @Override

--- a/src/main/java/com/example/atm/bounded_context/user/entity/User.java
+++ b/src/main/java/com/example/atm/bounded_context/user/entity/User.java
@@ -51,7 +51,7 @@ public class User implements UserDetails {
 
     private Long socialId;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @OneToOne
     private User mate;
 
     @Builder

--- a/src/main/java/com/example/atm/bounded_context/user/entity/User.java
+++ b/src/main/java/com/example/atm/bounded_context/user/entity/User.java
@@ -51,7 +51,7 @@ public class User implements UserDetails {
 
     private Long socialId;
 
-    @OneToOne
+    @OneToOne(fetch = FetchType.LAZY)
     private User mate;
 
     @Builder

--- a/src/main/java/com/example/atm/bounded_context/user/repository/UserRepository.java
+++ b/src/main/java/com/example/atm/bounded_context/user/repository/UserRepository.java
@@ -7,4 +7,6 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
+
+    Optional<User> findBySocialId(Long socialId);
 }

--- a/src/main/java/com/example/atm/bounded_context/user/service/UserService.java
+++ b/src/main/java/com/example/atm/bounded_context/user/service/UserService.java
@@ -54,6 +54,8 @@ public class UserService {
     @Transactional
     public void disconnectMate(Long userId) {
         User user = read(userId);
+        if (user.getMate() == null)
+            throw new IllegalArgumentException("본인의 짝꿍이 존재하지 않습니다.");
         user.disconnectMate(read(user.getMate().getId()));
     }
 

--- a/src/main/java/com/example/atm/bounded_context/user/service/UserService.java
+++ b/src/main/java/com/example/atm/bounded_context/user/service/UserService.java
@@ -32,6 +32,18 @@ public class UserService {
     }
 
     @Transactional
+    public void connectMate(Long acceptUserId, Long requestUserId) {
+        User user = read(acceptUserId);
+        user.connectMate(read(requestUserId));
+    }
+
+    @Transactional
+    public void disconnectMate(Long acceptUserId, Long requestUserId) {
+        User user = read(acceptUserId);
+        user.disconnectMate(read(requestUserId));
+    }
+
+    @Transactional
     public void delete(User user) {
         userRepository.delete(user);
     }

--- a/src/main/java/com/example/atm/bounded_context/user/service/UserService.java
+++ b/src/main/java/com/example/atm/bounded_context/user/service/UserService.java
@@ -42,14 +42,19 @@ public class UserService {
     @Transactional
     public void connectMate(Long userId, Long socialId) {
         User user = read(userId);
-        if (user.getMate() != null) throw new IllegalArgumentException(user.getMate().getNickname() + "이미 짝꿍이 존재합니다.");
+        if (user.getMate() != null)
+            throw new IllegalArgumentException("본인의 짝꿍이 이미 존재합니다.");
+
+        User mate = findBySocialId(socialId);
+        if (mate.getMate() != null)
+            throw new IllegalArgumentException("대상자 짝꿍이 이미 존재합니다.");
         user.connectMate(findBySocialId(socialId));
     }
 
     @Transactional
-    public void disconnectMate(Long acceptUserId, Long requestUserId) {
-        User user = read(acceptUserId);
-        user.disconnectMate(read(requestUserId));
+    public void disconnectMate(Long userId) {
+        User user = read(userId);
+        user.disconnectMate(read(user.getMate().getId()));
     }
 
     @Transactional

--- a/src/main/java/com/example/atm/bounded_context/user/service/UserService.java
+++ b/src/main/java/com/example/atm/bounded_context/user/service/UserService.java
@@ -3,10 +3,12 @@ package com.example.atm.bounded_context.user.service;
 import com.example.atm.bounded_context.user.entity.User;
 import com.example.atm.bounded_context.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class UserService {
 
@@ -24,6 +26,12 @@ public class UserService {
                 .orElseThrow(() -> new IllegalArgumentException(email + ":사용자가 존재하지 않습니다."));
     }
 
+    @Transactional(readOnly = true)
+    public User findBySocialId(Long socialId) {
+        return userRepository.findBySocialId(socialId)
+                .orElseThrow(() -> new IllegalArgumentException(socialId + ":사용자가 존재하지 않습니다."));
+    }
+
     @Transactional
     public User saveOrUpdate(User user) {
         return userRepository.findByEmail(user.getEmail())
@@ -32,9 +40,10 @@ public class UserService {
     }
 
     @Transactional
-    public void connectMate(Long acceptUserId, Long requestUserId) {
-        User user = read(acceptUserId);
-        user.connectMate(read(requestUserId));
+    public void connectMate(Long userId, Long socialId) {
+        User user = read(userId);
+        if (user.getMate() != null) throw new IllegalArgumentException(user.getMate().getNickname() + "이미 짝꿍이 존재합니다.");
+        user.connectMate(findBySocialId(socialId));
     }
 
     @Transactional


### PR DESCRIPTION
### 🚀 작업 동기 및 이슈

본인 또는 유저의 정보를 조회하고, 유저간의 관계를 짝꿍으로 설정 및 해제하는 API 필요

- close: #22 
- close: #23 
- close: #24 

### 🚧 변경 사항

- 본인 정보 조회 API
    
    사용자는 access token 으로 본인의 정보를 조회할 수 있습니다.
    
- 사용자 정보 조회 API - 보류
    
    사용자는 userId 로 대상 사용자의 정보를 조회할 수 있습니다. 현재 짝꿍 이외의 다른 사용자의 정보를 조회하는 기능을 사용하지 않으므로 보류했습니다.
    
- 짝꿍 연결하는 API
    
    사용자는 sociald 로 대상 사용자와 짝꿍 연결할 수 있습니다. 항상 1:1 관계를 유지하기 위해서 사용자의 짝꿍과 대상 사용자의 짝꿍이 없는 경우에만 정상호출 될 수있도록 구성했습니다.
    
- 짝꿍 해제하는 API
    
    사용자는 기존 짝꿍을 해제할 수 있습니다. 항상 1:1 관계를 유지하기 위해서 사용자의 짝꿍과 짝꿍의 짝꿍을 해제하도록 구성했습니다.
    

### 🧪 테스트 결과
- GET : {{ip}}/user/me
	
    <img width="1000" alt="Pasted image 20240719015013" src="https://github.com/user-attachments/assets/fa0b795a-d456-4868-8c64-7eedbd65011a">

- PATCH : {{ip}}/user/connect/{socialId}
	
    <img width="1004" alt="Pasted image 20240719015134" src="https://github.com/user-attachments/assets/8d6b0f8b-3278-44fd-9721-9b960ee257e8">

    <img width="789" alt="Pasted image 20240719015552" src="https://github.com/user-attachments/assets/ba698e37-dcee-4a18-828c-e1f862ea6ee3">

- PATCH : {{ip}}/user/disconnect
    <img width="1006" alt="Pasted image 20240719015251" src="https://github.com/user-attachments/assets/8a51829a-eef7-487f-be2d-c6f5d9c5a557">
    <img width="786" alt="Pasted image 20240719015420" src="https://github.com/user-attachments/assets/c75f262e-0741-4e5e-b9f3-6bf9475fc495">

### 📌 참고사항

- 현재 즉시 로딩을 적용하여 유저를 조회할 때 짝꿍도 함께 조회하여 가져오도록 했습니다. 지연 로딩을 사용하는 것이 더 좋지만, 사용자와 짝꿍 정보가 같이 표시되는 경우가 많고, 다른 도메인 API 를 설계하지 않아 반환값이 불확실하여 일단 즉시로딩을 사용하였습니다. 추후에 지연로딩을 사용하는 방식으로 변경하도록 할 것입니다.