### PR TITLE
로그인 및 회원가입 API 수정, Auth 명세서 작성

### DIFF
--- a/src/main/java/com/example/holing/base/exception/ExceptionResponse.java
+++ b/src/main/java/com/example/holing/base/exception/ExceptionResponse.java
@@ -14,4 +14,12 @@ public record ExceptionResponse(
                 exceptionCode.getCause()
         );
     }
+
+    public static ExceptionResponse fromEntity(String name, Exception e) {
+        return new ExceptionResponse(
+                LocalDateTime.now(),
+                name,
+                e.getMessage()
+        );
+    }
 }

--- a/src/main/java/com/example/holing/base/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/holing/base/exception/GlobalExceptionHandler.java
@@ -1,8 +1,14 @@
 package com.example.holing.base.exception;
 
+import com.example.holing.bounded_context.auth.exception.AuthExceptionCode;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.security.SignatureException;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.client.HttpClientErrorException;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -11,5 +17,38 @@ public class GlobalExceptionHandler {
         ExceptionCode exceptionCode = e.getExceptionCode();
         ExceptionResponse response = ExceptionResponse.fromEntity(exceptionCode);
         return ResponseEntity.status(exceptionCode.getHttpStatus()).body(response);
+    }
+
+    //API 호출 관련 예외
+    @ExceptionHandler(HttpClientErrorException.class)
+    public ResponseEntity<ExceptionResponse> handler(HttpClientErrorException e) {
+        ExceptionResponse response = ExceptionResponse.fromEntity("API_ERROR", e);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+    }
+
+    //JWT 유효성 검사 관련 예외
+    @ExceptionHandler(SignatureException.class)
+    protected ResponseEntity<ExceptionResponse> handler(SignatureException e) {
+        ExceptionResponse response = ExceptionResponse.fromEntity(AuthExceptionCode.INVALID_TOKEN);
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(response);
+    }
+
+    @ExceptionHandler(MalformedJwtException.class)
+    protected ResponseEntity<ExceptionResponse> handler(MalformedJwtException e) {
+        ExceptionResponse response = ExceptionResponse.fromEntity(AuthExceptionCode.WRONG_TOKEN);
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(response);
+    }
+
+    @ExceptionHandler(ExpiredJwtException.class)
+    protected ResponseEntity<ExceptionResponse> handler(ExpiredJwtException e) {
+        ExceptionResponse response = ExceptionResponse.fromEntity(AuthExceptionCode.EXPIRE_TOKEN);
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(response);
+    }
+
+    //SYSTEM
+    @ExceptionHandler(Exception.class)
+    protected ResponseEntity<ExceptionResponse> handler(Exception e) {
+        ExceptionResponse response = ExceptionResponse.fromEntity("SYSTEM_ERROR", e);
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
     }
 }

--- a/src/main/java/com/example/holing/base/jwt/JwtProvider.java
+++ b/src/main/java/com/example/holing/base/jwt/JwtProvider.java
@@ -1,5 +1,7 @@
 package com.example.holing.base.jwt;
 
+import com.example.holing.base.exception.GlobalException;
+import com.example.holing.bounded_context.auth.exception.AuthExceptionCode;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
@@ -48,7 +50,7 @@ public class JwtProvider {
      */
     public String getToken(HttpServletRequest request) {
         if (request.getHeader(AUTH_HEADER) == null)
-            throw new IllegalArgumentException("ApiExceptionCode.EMPTY_AUTHORIZATION");
+            throw new GlobalException(AuthExceptionCode.EMPTY_AUTHORIZATION);
         return parseToken(request.getHeader(AUTH_HEADER));
     }
 
@@ -61,7 +63,7 @@ public class JwtProvider {
      */
     public String parseToken(String token) {
         if (!token.startsWith(BEARER))
-            throw new IllegalArgumentException("ApiExceptionCode.EMPTY_BEARER");
+            throw new GlobalException(AuthExceptionCode.MISMATCH_TOKEN_TYPE);
         return token.substring(BEARER.length());
     }
 

--- a/src/main/java/com/example/holing/bounded_context/auth/api/AuthApi.java
+++ b/src/main/java/com/example/holing/bounded_context/auth/api/AuthApi.java
@@ -1,0 +1,66 @@
+package com.example.holing.bounded_context.auth.api;
+
+import com.example.holing.bounded_context.auth.dto.OAuthTokenInfoDto;
+import com.example.holing.bounded_context.auth.dto.SignInRequestDto;
+import com.example.holing.bounded_context.user.dto.UserInfoResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.servlet.view.RedirectView;
+
+@RequestMapping("/auth")
+@Tag(name = "[인증 관련 API]", description = "인증 관련 API")
+public interface AuthApi {
+    @GetMapping("/authorize")
+    @Operation(summary = "소셜 인증", description = "사용자가 소셜 인증을 받기 위한 API 입니다.<br>로그인 후 서비스 필수 항목에 동의가 완료되면 /auth/token 을 호출합니다.")
+    RedirectView authorize();
+
+    @GetMapping("/token")
+    @Operation(summary = "소셜 인증 토큰 반환", description = "사용자가 소셜 인증 토큰을 받기 위한 API 입니다.")
+    ResponseEntity<OAuthTokenInfoDto> token(@RequestParam("code") String code);
+
+    @PostMapping("/signIn")
+    @Operation(summary = "로그인 및 회원가입", description = "사용자가 로그인 및 회원가입을 위한 API 입니다.<br>회원가입의 경우 자가테스트의 사용자 정보가 필요합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "사용자 로그인 성공"),
+            @ApiResponse(responseCode = "400", description = "소셜 인증 서버에서 오류가 발생한 경우",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                                                                {
+                                                                                    "timestamp": "2024-07-19T17:56:39.188+00:00",
+                                                                                    "name": "API_ERROR",
+                                                                                    "cause": "401 Unauthorized: \\"{\\"msg\\":\\"this access token does not exist\\",\\"code\\":-401}\\""
+                                                                                }
+                                    """)
+                    }))
+    })
+    ResponseEntity<UserInfoResponseDto> signIn(@RequestBody SignInRequestDto request);
+
+    @DeleteMapping("/withdrawal")
+    @Operation(summary = "회원 탈퇴[임시]", description = "사용자가 서비스와 연결을 끊고 회원을 탈퇴하기 위한 API 입니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "사용자 회원 탈퇴 성공"),
+            @ApiResponse(responseCode = "400", description = "소셜 인증 서버에서 오류가 발생한 경우",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                                                                {
+                                                                                    "timestamp": "2024-07-19T17:56:39.188+00:00",
+                                                                                    "name": "API_ERROR",
+                                                                                    "cause": "401 Unauthorized: \\"{\\"msg\\":\\"this access token does not exist\\",\\"code\\":-401}\\""
+                                                                                }
+                                    """)
+                    }))
+    })
+    ResponseEntity<String> withdrawal(HttpServletRequest request);
+}

--- a/src/main/java/com/example/holing/bounded_context/auth/controller/AuthController.java
+++ b/src/main/java/com/example/holing/bounded_context/auth/controller/AuthController.java
@@ -1,6 +1,7 @@
 package com.example.holing.bounded_context.auth.controller;
 
 import com.example.holing.base.jwt.JwtProvider;
+import com.example.holing.bounded_context.auth.api.AuthApi;
 import com.example.holing.bounded_context.auth.dto.OAuthTokenInfoDto;
 import com.example.holing.bounded_context.auth.dto.OAuthUserInfoDto;
 import com.example.holing.bounded_context.auth.dto.SignInRequestDto;
@@ -12,9 +13,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -25,7 +23,7 @@ import org.springframework.web.servlet.view.RedirectView;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/auth")
-public class AuthController {
+public class AuthController implements AuthApi {
 
     private final OAuthService oAuthService;
     private final UserService userService;
@@ -42,7 +40,7 @@ public class AuthController {
      *
      * @return uri
      */
-    @GetMapping("/authorize")
+    @Override
     public RedirectView authorize() {
         String uri = oAuthService.getAuthorizeUri();
         return new RedirectView(uri);
@@ -55,7 +53,7 @@ public class AuthController {
      * @return TokenInfoDto 발급된 토큰
      * @throws HttpClientErrorException 토큰 발급 받기 api 요청 실패 시 발생합니다.
      */
-    @GetMapping("/token")
+    @Override
     public ResponseEntity<OAuthTokenInfoDto> token(@RequestParam("code") String code) {
         OAuthTokenInfoDto token = oAuthService.getToken(code);
         return ResponseEntity.ok().body(token);
@@ -70,7 +68,7 @@ public class AuthController {
      * @return UserInfoDto 유저 정보
      * @throws HttpClientErrorException 사용자 정보 받기 api 요청 실패 시 발생합니다.
      */
-    @PostMapping("/signIn")
+    @Override
     public ResponseEntity<UserInfoResponseDto> signIn(@RequestBody SignInRequestDto request) {
         OAuthUserInfoDto userInfo = oAuthService.getUserInfo(request.accessToken());
         User user = userService.saveOrUpdate(User.of(userInfo, request));
@@ -92,7 +90,7 @@ public class AuthController {
      * @throws HttpClientErrorException 연결 끊기 api 요청 실패 시 발생합니다.
      * @throws IllegalArgumentException 회원이 조회되지 않는 경우 발생합니다.
      */
-    @DeleteMapping("/withdrawal")
+    @Override
     public ResponseEntity<String> withdrawal(HttpServletRequest request) {
         String accessToken = jwtProvider.getToken(request);
         String userId = jwtProvider.getUserId(accessToken);

--- a/src/main/java/com/example/holing/bounded_context/auth/controller/AuthController.java
+++ b/src/main/java/com/example/holing/bounded_context/auth/controller/AuthController.java
@@ -3,6 +3,7 @@ package com.example.holing.bounded_context.auth.controller;
 import com.example.holing.base.jwt.JwtProvider;
 import com.example.holing.bounded_context.auth.dto.OAuthTokenInfoDto;
 import com.example.holing.bounded_context.auth.dto.OAuthUserInfoDto;
+import com.example.holing.bounded_context.auth.dto.SignInRequestDto;
 import com.example.holing.bounded_context.auth.service.OAuthService;
 import com.example.holing.bounded_context.user.dto.UserInfoResponseDto;
 import com.example.holing.bounded_context.user.entity.User;
@@ -70,9 +71,9 @@ public class AuthController {
      * @throws HttpClientErrorException 사용자 정보 받기 api 요청 실패 시 발생합니다.
      */
     @PostMapping("/signIn")
-    public ResponseEntity<UserInfoResponseDto> signIn(@RequestBody OAuthTokenInfoDto request) {
+    public ResponseEntity<UserInfoResponseDto> signIn(@RequestBody SignInRequestDto request) {
         OAuthUserInfoDto userInfo = oAuthService.getUserInfo(request.accessToken());
-        User user = userService.saveOrUpdate(User.fromEntity(userInfo));
+        User user = userService.saveOrUpdate(User.of(userInfo, request));
 
         String accessToken = jwtProvider.generatorAccessToken(user.getEmail(), user.getId());
         HttpHeaders headers = new HttpHeaders();

--- a/src/main/java/com/example/holing/bounded_context/auth/dto/SignInRequestDto.java
+++ b/src/main/java/com/example/holing/bounded_context/auth/dto/SignInRequestDto.java
@@ -1,10 +1,14 @@
 package com.example.holing.bounded_context.auth.dto;
 
 import com.example.holing.bounded_context.user.entity.Gender;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 public record SignInRequestDto(
+        @Schema(description = "소셜 인증 토큰", example = "Bearer example-token-value")
         String accessToken,
+        @Schema(description = "유저 성별[최초가입시 필수]", example = "MALE")
         Gender gender,
+        @Schema(description = "월경 정보[최초가입시 필수]", example = "false")
         Boolean isPeriod
 ) {
 }

--- a/src/main/java/com/example/holing/bounded_context/auth/dto/SignInRequestDto.java
+++ b/src/main/java/com/example/holing/bounded_context/auth/dto/SignInRequestDto.java
@@ -1,0 +1,10 @@
+package com.example.holing.bounded_context.auth.dto;
+
+import com.example.holing.bounded_context.user.entity.Gender;
+
+public record SignInRequestDto(
+        String accessToken,
+        Gender gender,
+        Boolean isPeriod
+) {
+}

--- a/src/main/java/com/example/holing/bounded_context/auth/exception/AuthExceptionCode.java
+++ b/src/main/java/com/example/holing/bounded_context/auth/exception/AuthExceptionCode.java
@@ -1,0 +1,37 @@
+package com.example.holing.bounded_context.auth.exception;
+
+import com.example.holing.base.exception.ExceptionCode;
+import org.springframework.http.HttpStatus;
+
+public enum AuthExceptionCode implements ExceptionCode {
+
+    //Authorization
+    EMPTY_AUTHORIZATION(HttpStatus.BAD_REQUEST, "인증 값이 비어있습니다."),
+    MISMATCH_TOKEN_TYPE(HttpStatus.BAD_REQUEST, "Bearer 토큰이 아닙니다"),
+    WRONG_TOKEN(HttpStatus.UNAUTHORIZED, "올바르지 않은 토큰형식 입니다."),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 서명의 토큰 입니다."),
+    EXPIRE_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다.");
+
+    HttpStatus httpStatus;
+    String cause;
+
+    AuthExceptionCode(HttpStatus httpStatus, String cause) {
+        this.httpStatus = httpStatus;
+        this.cause = cause;
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String getCause() {
+        return cause;
+    }
+
+    @Override
+    public String getName() {
+        return name();
+    }
+}

--- a/src/main/java/com/example/holing/bounded_context/user/dto/UserInfoResponseDto.java
+++ b/src/main/java/com/example/holing/bounded_context/user/dto/UserInfoResponseDto.java
@@ -21,7 +21,7 @@ public record UserInfoResponseDto(
         @Schema(description = "월경 정보", example = "false")
         Boolean isPeriod,
         @Schema(description = "유저 포인트", example = "100")
-        Integer point,
+        int point,
         @Schema(description = "소셜 ID", example = "1234567890")
         Long socialId,
         @Schema(description = "짝꿍 ID", example = "2")

--- a/src/main/java/com/example/holing/bounded_context/user/dto/UserInfoResponseDto.java
+++ b/src/main/java/com/example/holing/bounded_context/user/dto/UserInfoResponseDto.java
@@ -16,8 +16,10 @@ public record UserInfoResponseDto(
         String nickname,
         @Schema(description = "프로필 이미지 URL", example = "http://example.com/image.jpg")
         String profileImgUrl,
-        @Schema(description = "유저 성별", example = "M")
+        @Schema(description = "유저 성별", example = "MALE")
         Gender gender,
+        @Schema(description = "월경 정보", example = "false")
+        Boolean isPeriod,
         @Schema(description = "유저 포인트", example = "100")
         Integer point,
         @Schema(description = "소셜 ID", example = "1234567890")
@@ -32,6 +34,7 @@ public record UserInfoResponseDto(
                 user.getNickname(),
                 user.getProfileImgUrl(),
                 user.getGender(),
+                user.getIsPeriod(),
                 user.getPoint(),
                 user.getSocialId(),
                 Optional.ofNullable(user.getMate())

--- a/src/main/java/com/example/holing/bounded_context/user/entity/User.java
+++ b/src/main/java/com/example/holing/bounded_context/user/entity/User.java
@@ -1,6 +1,7 @@
 package com.example.holing.bounded_context.user.entity;
 
 import com.example.holing.bounded_context.auth.dto.OAuthUserInfoDto;
+import com.example.holing.bounded_context.auth.dto.SignInRequestDto;
 import com.example.holing.bounded_context.schedule.entity.Schedule;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -47,6 +48,8 @@ public class User implements UserDetails {
 
     private Gender gender;
 
+    private Boolean isPeriod;
+
     private Integer point;
 
     private Long socialId;
@@ -55,29 +58,31 @@ public class User implements UserDetails {
     private User mate;
 
     @Builder
-    public User(String email, String password, String nickname, String profileImgUrl, Gender gender, Integer point, Long socialId) {
+    public User(String email, String password, String nickname, String profileImgUrl, Gender gender, Boolean isPeriod, Integer point, Long socialId) {
         this.email = email;
         this.password = password;
         this.nickname = nickname;
         this.profileImgUrl = profileImgUrl;
         this.gender = gender;
-        this.point = point;
+        this.isPeriod = (gender == Gender.FEMALE) ? isPeriod : false;
+        this.point = 0;
         this.socialId = socialId;
     }
 
-    public static User fromEntity(OAuthUserInfoDto dto) {
+    public static User of(OAuthUserInfoDto dto, SignInRequestDto request) {
         return User.builder()
                 .email(dto.email())
                 .nickname(dto.nickname())
                 .profileImgUrl(dto.profileImageUrl())
                 .socialId(dto.id())
+                .gender(request.gender())
+                .isPeriod(request.isPeriod())
                 .build();
     }
 
-    public User update(String nickname, String profileImgUrl, Gender gender) {
+    public User update(String nickname, String profileImgUrl) {
         this.nickname = nickname;
         this.profileImgUrl = profileImgUrl;
-        this.gender = gender;
         return this;
     }
 

--- a/src/main/java/com/example/holing/bounded_context/user/entity/User.java
+++ b/src/main/java/com/example/holing/bounded_context/user/entity/User.java
@@ -53,7 +53,7 @@ public class User implements UserDetails {
     private Boolean isPeriod;
 
     @Column(nullable = false)
-    private Integer point;
+    private int point;
 
     @Column(nullable = false)
     private Long socialId;

--- a/src/main/java/com/example/holing/bounded_context/user/entity/User.java
+++ b/src/main/java/com/example/holing/bounded_context/user/entity/User.java
@@ -46,12 +46,16 @@ public class User implements UserDetails {
     @Column(nullable = false)
     private String profileImgUrl;
 
+    @Column(nullable = false)
     private Gender gender;
 
+    @Column(nullable = false)
     private Boolean isPeriod;
 
+    @Column(nullable = false)
     private Integer point;
 
+    @Column(nullable = false)
     private Long socialId;
 
     @OneToOne

--- a/src/main/java/com/example/holing/bounded_context/user/service/UserService.java
+++ b/src/main/java/com/example/holing/bounded_context/user/service/UserService.java
@@ -31,7 +31,9 @@ public class UserService {
     @Transactional
     public User saveOrUpdate(User user) {
         return userRepository.findByEmail(user.getEmail())
-                .map(entity -> entity.update(user.getNickname(), user.getProfileImgUrl(), user.getGender()))
+                .map(entity -> entity.update(
+                        user.getNickname(),
+                        user.getProfileImgUrl()))
                 .orElseGet(() -> userRepository.save(user));
     }
 


### PR DESCRIPTION
### 🔥 작업 동기 및 이슈

- close: #

### 🛠️ 변경 사항

- 로그인 및 회원가입 API 수정
    - 최초가입자는 가입 이전에 테스트를 진행하게 되므로 요청 시 엑세스 토큰 뿐만 아니라 테스트에서 얻는 메타정보 성별, 월경유무를 포함하도록 합니다. 성별이 여자인 경우에만 월경 유무에 값이 적용됩니다.
    - 기존가입자는 엑세스 토큰만을 가지고 소셜 인증 서버에서 얻을 수 있는 정보만을 업데이트 하도록 합니다.
    - 비밀번호와 짝꿍 속성을 제외한 나머지 속성을 not null 로 수정하였습니다.
- auth API 명세서 작성  
- jwt 관련 예외 코드 및 핸들러 추가

### ☑️ 테스트 결과

- {{iip}}/auth/signIn FEMALE + false -> FEMALE + false
    <img width="1013" alt="h1" src="https://github.com/user-attachments/assets/251ac0de-e34a-4100-b1cd-ad5e4f41019b">

- {{iip}}/auth/signIn FEMALE + true -> FEMALE + true
    <img width="1008" alt="image" src="https://github.com/user-attachments/assets/e77e9330-6d3e-4a38-8a04-d3816a0bb4c0">

- {{ip}}/auth/signIn MATE + true -> MALE -> false
    <img width="1011" alt="12" src="https://github.com/user-attachments/assets/1802c9e9-f73e-4920-bcfd-11c2c3e07160">


### 🌟 참고사항

- 지난 코드에서 작성된 user api 명세서를 swagger 에서 확인해보시면 좋을 것 같습니다.