### PR TITLE
월별 일정 개수 조회 API 추가

### DIFF
--- a/src/main/java/com/example/holing/bounded_context/schedule/api/ScheduleApi.java
+++ b/src/main/java/com/example/holing/bounded_context/schedule/api/ScheduleApi.java
@@ -1,5 +1,6 @@
 package com.example.holing.bounded_context.schedule.api;
 
+import com.example.holing.bounded_context.schedule.dto.ScheduleCountDto;
 import com.example.holing.bounded_context.schedule.dto.ScheduleRequestDto;
 import com.example.holing.bounded_context.schedule.dto.ScheduleResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
@@ -25,6 +26,7 @@ import java.util.List;
 @Tag(name = "[캘린더 관련 일정 API]", description = "캘린더 기능의 일정 관련 API")
 public interface ScheduleApi {
 
+
     @GetMapping("/schedules")
     @Operation(summary = "선택한 날짜의 일정을 조회", description = "선택한 날짜의 일정을 조회하기 위한 API입니다.")
     @ApiResponses(value = {
@@ -41,6 +43,23 @@ public interface ScheduleApi {
                     }))
     })
     ResponseEntity<List<ScheduleResponseDto>> getDateSchedule(HttpServletRequest request, @RequestParam("date") String date);
+
+    @GetMapping("/schedules/month")
+    @Operation(summary = "선택한 날짜가 포함된 월의 모든 일정 개수를 조회", description = "선택된 날짜의 월에 포함된 모든 일정의 개수를 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "모든 일정 개수 카운팅 성공"),
+            @ApiResponse(responseCode = "404", description = "일정 개수 카운팅 실패",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                                                                {
+                                                                                    "timeStamp": "2024-07-24T00:30:09.9259602",
+                                                                                    "name": "SCHEDULE_NOT_FOUND",
+                                                                                    "cause": "일정을 찾을 수 없습니다."
+                                                                                }
+                                    """),
+                    }))
+    })
+    ResponseEntity<List<ScheduleCountDto>> getScheduleCount(HttpServletRequest request, @RequestParam("date") String date);
 
     @PostMapping("/schedules")
     @Operation(summary = "선택한 날짜의 일정을 생성", description = "선택한 날짜의 일정을 생성하기 위한 API입니다.")

--- a/src/main/java/com/example/holing/bounded_context/schedule/api/ScheduleApi.java
+++ b/src/main/java/com/example/holing/bounded_context/schedule/api/ScheduleApi.java
@@ -47,17 +47,7 @@ public interface ScheduleApi {
     @GetMapping("/schedules/month")
     @Operation(summary = "선택한 날짜가 포함된 월의 모든 일정 개수를 조회", description = "선택된 날짜의 월에 포함된 모든 일정의 개수를 조회합니다.")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "모든 일정 개수 카운팅 성공"),
-            @ApiResponse(responseCode = "404", description = "일정 개수 카운팅 실패",
-                    content = @Content(mediaType = "application/json", examples = {
-                            @ExampleObject(value = """
-                                                                                {
-                                                                                    "timeStamp": "2024-07-24T00:30:09.9259602",
-                                                                                    "name": "SCHEDULE_NOT_FOUND",
-                                                                                    "cause": "일정을 찾을 수 없습니다."
-                                                                                }
-                                    """),
-                    }))
+            @ApiResponse(responseCode = "200", description = "모든 일정 개수 카운팅 성공")
     })
     ResponseEntity<List<ScheduleCountDto>> getScheduleCount(HttpServletRequest request, @RequestParam("date") String date);
 

--- a/src/main/java/com/example/holing/bounded_context/schedule/api/ScheduleApi.java
+++ b/src/main/java/com/example/holing/bounded_context/schedule/api/ScheduleApi.java
@@ -1,0 +1,95 @@
+package com.example.holing.bounded_context.schedule.api;
+
+import com.example.holing.bounded_context.schedule.dto.ScheduleRequestDto;
+import com.example.holing.bounded_context.schedule.dto.ScheduleResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.List;
+
+@RequestMapping("/calendar")
+@Tag(name = "[캘린더 관련 일정 API]", description = "캘린더 기능의 일정 관련 API")
+public interface ScheduleApi {
+
+    @GetMapping("/schedules")
+    @Operation(summary = "선택한 날짜의 일정을 조회", description = "선택한 날짜의 일정을 조회하기 위한 API입니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "일정 조회 성공"),
+            @ApiResponse(responseCode = "404", description = "일정 조회 실패",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                                                                {
+                                                                                    "timeStamp": "2024-07-24T00:30:09.9259602",
+                                                                                    "name": "SCHEDULE_NOT_FOUND",
+                                                                                    "cause": "일정을 찾을 수 없습니다."
+                                                                                }
+                                    """),
+                    }))
+    })
+    ResponseEntity<List<ScheduleResponseDto>> getDateSchedule(HttpServletRequest request, @RequestParam("date") String date);
+
+    @PostMapping("/schedules")
+    @Operation(summary = "선택한 날짜의 일정을 생성", description = "선택한 날짜의 일정을 생성하기 위한 API입니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "일정 생성 성공"),
+            @ApiResponse(responseCode = "404", description = "일정 생성 실패",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                                                                {
+                                                                                    "timeStamp": "2024-07-24T00:30:09.9259602",
+                                                                                    "name": "INVALID_DATETIME",
+                                                                                    "cause": "잘못된 일정입니다."
+                                                                                }
+                                    """),
+                    })),
+    })
+    public ResponseEntity<ScheduleResponseDto> createSchedule(HttpServletRequest request, @RequestBody ScheduleRequestDto scheduleRequestDto);
+
+    @PutMapping("/schedules/{scheduleId}")
+    @Operation(summary = "선택한 날짜의 일정을 수정", description = "선택한 날짜의 일정을 수정하기 위한 API입니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "일정 수정 성공"),
+            @ApiResponse(responseCode = "404", description = "일정 수정 실패",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                                                                {
+                                                                                    "timeStamp": "2024-07-24T00:30:09.9259602",
+                                                                                    "name": "SCHEDULE_NOT_FOUND",
+                                                                                    "cause": "일정을 찾을 수 없습니다."
+                                                                                }
+                                    """),
+                    }))
+    })
+    public ResponseEntity<ScheduleResponseDto> updateSchedule(HttpServletRequest request, @PathVariable Long scheduleId, @RequestBody ScheduleRequestDto scheduleRequestDto);
+
+    @DeleteMapping("/schedules/{scheduleId}")
+    @Operation(summary = "선택한 날짜의 일정을 삭제", description = "선택한 날짜의 일정을 삭제하기 위한 API입니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "일정 삭제 성공"),
+            @ApiResponse(responseCode = "404", description = "일정 삭제 실패",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                                                                {
+                                                                                    "timeStamp": "2024-07-24T00:30:09.9259602",
+                                                                                    "name": "SCHEDULE_NOT_FOUND",
+                                                                                    "cause": "일정을 찾을 수 없습니다."
+                                                                                }
+                                    """),
+                    }))
+    })
+    public ResponseEntity<String> deleteSchedule(@PathVariable Long scheduleId);
+}

--- a/src/main/java/com/example/holing/bounded_context/schedule/api/SwaggerApi.java
+++ b/src/main/java/com/example/holing/bounded_context/schedule/api/SwaggerApi.java
@@ -1,0 +1,2 @@
+package com.example.holing.bounded_context.schedule.api;public interface SwaggerApi {
+}

--- a/src/main/java/com/example/holing/bounded_context/schedule/api/SwaggerApi.java
+++ b/src/main/java/com/example/holing/bounded_context/schedule/api/SwaggerApi.java
@@ -1,2 +1,0 @@
-package com.example.holing.bounded_context.schedule.api;public interface SwaggerApi {
-}

--- a/src/main/java/com/example/holing/bounded_context/schedule/controller/ScheduleController.java
+++ b/src/main/java/com/example/holing/bounded_context/schedule/controller/ScheduleController.java
@@ -1,30 +1,27 @@
 package com.example.holing.bounded_context.schedule.controller;
 
 import com.example.holing.base.jwt.JwtProvider;
+import com.example.holing.bounded_context.schedule.api.ScheduleApi;
 import com.example.holing.bounded_context.schedule.dto.ScheduleRequestDto;
 import com.example.holing.bounded_context.schedule.dto.ScheduleResponseDto;
 import com.example.holing.bounded_context.schedule.service.ScheduleService;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.time.LocalDate;
-import java.time.format.DateTimeParseException;
+import java.util.List;
 
 @RestController
 @RequestMapping("/calendar")
 @RequiredArgsConstructor
-public class ScheduleController {
+public class ScheduleController implements ScheduleApi {
 
     private final ScheduleService scheduleService;
 
@@ -36,17 +33,12 @@ public class ScheduleController {
      * @param date
      * @return 해당 날짜의 모든 일정
      */
-    @GetMapping("/schedules")
-    public ResponseEntity<?> getDateSchedule(HttpServletRequest request, @RequestParam("date") String date) {
-        try {
-            String accessToken = jwtProvider.getToken(request);
-            String userId = jwtProvider.getUserId(accessToken);
+    public ResponseEntity<List<ScheduleResponseDto>> getDateSchedule(HttpServletRequest request, @RequestParam("date") String date) {
+        String accessToken = jwtProvider.getToken(request);
+        String userId = jwtProvider.getUserId(accessToken);
 
-            LocalDate selectedDate = LocalDate.parse(date);
-            return new ResponseEntity<>(scheduleService.read(Long.parseLong(userId), selectedDate.atStartOfDay(), selectedDate.atStartOfDay().plusDays(1)), HttpStatus.OK);
-        } catch (DateTimeParseException e) {
-            return ResponseEntity.badRequest().body(e.getMessage());
-        }
+        LocalDate selectedDate = LocalDate.parse(date);
+        return ResponseEntity.ok().body(scheduleService.read(Long.parseLong(userId), selectedDate.atStartOfDay(), selectedDate.atStartOfDay().plusDays(1)));
     }
 
     /**
@@ -55,18 +47,13 @@ public class ScheduleController {
      * @param scheduleRequestDto
      * @return
      */
-    @PostMapping("/schedules")
-    public ResponseEntity<?> createSchedule(HttpServletRequest request, @RequestBody ScheduleRequestDto scheduleRequestDto) {
-        try {
-            String accessToken = jwtProvider.getToken(request);
-            String userId = jwtProvider.getUserId(accessToken);
+    public ResponseEntity<ScheduleResponseDto> createSchedule(HttpServletRequest request, @RequestBody ScheduleRequestDto scheduleRequestDto) {
+        String accessToken = jwtProvider.getToken(request);
+        String userId = jwtProvider.getUserId(accessToken);
 
-            ScheduleResponseDto scheduleResponseDto = scheduleService.create(Long.parseLong(userId), scheduleRequestDto);
+        ScheduleResponseDto scheduleResponseDto = scheduleService.create(Long.parseLong(userId), scheduleRequestDto);
 
-            return ResponseEntity.ok(scheduleResponseDto);
-        } catch (Exception e) {
-            return ResponseEntity.badRequest().body(e.getMessage());
-        }
+        return ResponseEntity.ok().body(scheduleResponseDto);
     }
 
     /**
@@ -75,16 +62,11 @@ public class ScheduleController {
      * @param scheduleId
      * @param scheduleRequestDto - 수정된 일정 사항
      */
-    @PutMapping("/schedules/{scheduleId}")
-    public ResponseEntity<?> updateSchedule(HttpServletRequest request, @PathVariable Long scheduleId, @RequestBody ScheduleRequestDto scheduleRequestDto) {
-        try {
-            String accessToken = jwtProvider.getToken(request);
-            String userId = jwtProvider.getUserId(accessToken);
+    public ResponseEntity<ScheduleResponseDto> updateSchedule(HttpServletRequest request, @PathVariable Long scheduleId, @RequestBody ScheduleRequestDto scheduleRequestDto) {
+        String accessToken = jwtProvider.getToken(request);
+        String userId = jwtProvider.getUserId(accessToken);
 
-            return ResponseEntity.ok(scheduleService.update(Long.parseLong(userId), scheduleId, scheduleRequestDto));
-        } catch (Exception e) {
-            return ResponseEntity.badRequest().body(e.getMessage());
-        }
+        return ResponseEntity.ok().body(scheduleService.update(Long.parseLong(userId), scheduleId, scheduleRequestDto));
     }
 
     /**
@@ -93,7 +75,7 @@ public class ScheduleController {
      * @param scheduleId
      */
     @DeleteMapping("/schedules/{scheduleId}")
-    public ResponseEntity<?> deleteSchedule(@PathVariable Long scheduleId) {
+    public ResponseEntity<String> deleteSchedule(@PathVariable Long scheduleId) {
         scheduleService.delete(scheduleId);
         return ResponseEntity.ok("일정 삭제 완료");
     }

--- a/src/main/java/com/example/holing/bounded_context/schedule/controller/ScheduleController.java
+++ b/src/main/java/com/example/holing/bounded_context/schedule/controller/ScheduleController.java
@@ -2,6 +2,7 @@ package com.example.holing.bounded_context.schedule.controller;
 
 import com.example.holing.base.jwt.JwtProvider;
 import com.example.holing.bounded_context.schedule.api.ScheduleApi;
+import com.example.holing.bounded_context.schedule.dto.ScheduleCountDto;
 import com.example.holing.bounded_context.schedule.dto.ScheduleRequestDto;
 import com.example.holing.bounded_context.schedule.dto.ScheduleResponseDto;
 import com.example.holing.bounded_context.schedule.service.ScheduleService;
@@ -16,6 +17,8 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.YearMonth;
 import java.util.List;
 
 @RestController
@@ -40,6 +43,24 @@ public class ScheduleController implements ScheduleApi {
         LocalDate selectedDate = LocalDate.parse(date);
         return ResponseEntity.ok().body(scheduleService.read(Long.parseLong(userId), selectedDate.atStartOfDay(), selectedDate.atStartOfDay().plusDays(1)));
     }
+
+    /**
+     * 해당 월의 모든 날짜에 일정 개수를 반환함
+     */
+
+    public ResponseEntity<List<ScheduleCountDto>> getScheduleCount(HttpServletRequest request, @RequestParam("date") String date) {
+        String accessToken = jwtProvider.getToken(request);
+        String userId = jwtProvider.getUserId(accessToken);
+
+        LocalDate selectedDate = LocalDate.parse(date);
+
+        YearMonth yearMonth = YearMonth.from(selectedDate);
+        LocalDateTime firstDay = yearMonth.atDay(1).atStartOfDay();
+        LocalDateTime lastDay = yearMonth.atEndOfMonth().atTime(23, 59, 59);
+
+        return ResponseEntity.ok().body(scheduleService.countSchedules(Long.parseLong(userId), firstDay, lastDay));
+    }
+
 
     /**
      * 일정 등록

--- a/src/main/java/com/example/holing/bounded_context/schedule/controller/ScheduleController.java
+++ b/src/main/java/com/example/holing/bounded_context/schedule/controller/ScheduleController.java
@@ -5,23 +5,30 @@ import com.example.holing.bounded_context.schedule.dto.ScheduleRequestDto;
 import com.example.holing.bounded_context.schedule.dto.ScheduleResponseDto;
 import com.example.holing.bounded_context.schedule.service.ScheduleService;
 import jakarta.servlet.http.HttpServletRequest;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeParseException;
 
 @RestController
 @RequestMapping("/calendar")
+@RequiredArgsConstructor
 public class ScheduleController {
 
-    @Autowired
-    private ScheduleService scheduleService;
+    private final ScheduleService scheduleService;
 
-    @Autowired
-    private JwtProvider jwtProvider;
+    private final JwtProvider jwtProvider;
 
     /**
      * 특정 날짜의 일정을 조회

--- a/src/main/java/com/example/holing/bounded_context/schedule/dto/ScheduleCountDto.java
+++ b/src/main/java/com/example/holing/bounded_context/schedule/dto/ScheduleCountDto.java
@@ -1,0 +1,12 @@
+package com.example.holing.bounded_context.schedule.dto;
+
+import java.time.LocalDate;
+
+public record ScheduleCountDto(
+        LocalDate date,
+        int count
+) {
+    public ScheduleCountDto scheduleCountDto(LocalDate date, int count) {
+        return new ScheduleCountDto(date, count);
+    }
+}

--- a/src/main/java/com/example/holing/bounded_context/schedule/dto/ScheduleRequestDto.java
+++ b/src/main/java/com/example/holing/bounded_context/schedule/dto/ScheduleRequestDto.java
@@ -6,14 +6,14 @@ import java.time.LocalDateTime;
 
 public record ScheduleRequestDto(
         String title,
-        String place,
+        String content,
         LocalDateTime startAt,
         LocalDateTime finishAt
 ) {
     public Schedule toEntity() {
         return Schedule.builder()
                 .title(title)
-                .place(place)
+                .content(content)
                 .startAt(startAt)
                 .finishAt(finishAt)
                 .build();

--- a/src/main/java/com/example/holing/bounded_context/schedule/dto/ScheduleResponseDto.java
+++ b/src/main/java/com/example/holing/bounded_context/schedule/dto/ScheduleResponseDto.java
@@ -7,7 +7,7 @@ import java.time.LocalDateTime;
 public record ScheduleResponseDto(
         Long id,
         String title,
-        String place,
+        String content,
         LocalDateTime startAt,
         LocalDateTime finishAt
 ) {
@@ -15,7 +15,7 @@ public record ScheduleResponseDto(
         return new ScheduleResponseDto(
                 schedule.getId(),
                 schedule.getTitle(),
-                schedule.getPlace(),
+                schedule.getContent(),
                 schedule.getStartAt(),
                 schedule.getFinishAt()
         );

--- a/src/main/java/com/example/holing/bounded_context/schedule/entity/Schedule.java
+++ b/src/main/java/com/example/holing/bounded_context/schedule/entity/Schedule.java
@@ -24,7 +24,7 @@ public class Schedule {
     private String title;
 
     @Column(nullable = true)
-    private String place;
+    private String content;
 
     @Column(nullable = false)
     private LocalDateTime startAt;
@@ -33,16 +33,16 @@ public class Schedule {
     private LocalDateTime finishAt;
 
     @Builder
-    public Schedule(String title, String place, LocalDateTime startAt, LocalDateTime finishAt) {
+    public Schedule(String title, String content, LocalDateTime startAt, LocalDateTime finishAt) {
         this.title = title;
-        this.place = place;
+        this.content = content;
         this.startAt = startAt;
         this.finishAt = finishAt;
     }
 
-    public void update(String title, String place, LocalDateTime startAt, LocalDateTime finishAt) {
+    public void update(String title, String content, LocalDateTime startAt, LocalDateTime finishAt) {
         this.title = title;
-        this.place = place;
+        this.content = content;
         this.startAt = startAt;
         this.finishAt = finishAt;
     }

--- a/src/main/java/com/example/holing/bounded_context/schedule/exception/ScheduleExceptionCode.java
+++ b/src/main/java/com/example/holing/bounded_context/schedule/exception/ScheduleExceptionCode.java
@@ -1,0 +1,32 @@
+package com.example.holing.bounded_context.schedule.exception;
+
+import com.example.holing.base.exception.ExceptionCode;
+import org.springframework.http.HttpStatus;
+
+public enum ScheduleExceptionCode implements ExceptionCode {
+    SCHEDULE_NOT_FOUND(HttpStatus.NOT_FOUND, "일정을 찾을 수 없습니다."),
+    INVALID_DATETIME(HttpStatus.BAD_REQUEST, "잘못된 일정입니다.");
+    
+    HttpStatus httpStatus;
+    String cause;
+
+    ScheduleExceptionCode(HttpStatus httpStatus, String cause) {
+        this.httpStatus = httpStatus;
+        this.cause = cause;
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String getCause() {
+        return cause;
+    }
+
+    @Override
+    public String getName() {
+        return name();
+    }
+}

--- a/src/main/java/com/example/holing/bounded_context/schedule/service/ScheduleService.java
+++ b/src/main/java/com/example/holing/bounded_context/schedule/service/ScheduleService.java
@@ -8,8 +8,7 @@ import com.example.holing.bounded_context.schedule.entity.Schedule;
 import com.example.holing.bounded_context.schedule.exception.ScheduleExceptionCode;
 import com.example.holing.bounded_context.schedule.repository.ScheduleRepository;
 import com.example.holing.bounded_context.user.entity.User;
-import com.example.holing.bounded_context.user.exception.UserExceptionCode;
-import com.example.holing.bounded_context.user.repository.UserRepository;
+import com.example.holing.bounded_context.user.service.UserService;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -30,7 +29,7 @@ public class ScheduleService {
 
     private final ScheduleRepository scheduleRepository;
 
-    private final UserRepository userRepository;
+    private final UserService userService;
 
     /**
      * 일정 등록
@@ -39,8 +38,7 @@ public class ScheduleService {
      */
     public ScheduleResponseDto create(Long userId, ScheduleRequestDto scheduleRequestDto) {
 
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new GlobalException(UserExceptionCode.USER_NOT_FOUND));
+        User user = userService.read(userId);
 
         validate(scheduleRequestDto.startAt(), scheduleRequestDto.finishAt());
         Schedule schedule = scheduleRequestDto.toEntity();
@@ -58,8 +56,7 @@ public class ScheduleService {
      */
     public List<ScheduleResponseDto> read(Long userId, LocalDateTime startAt, LocalDateTime finishAt) {
 
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new GlobalException(UserExceptionCode.USER_NOT_FOUND));
+        User user = userService.read(userId);
 
         List<Schedule> mySchedules = scheduleRepository.findByUserIdAndStartAtBetweenOrderByStartAtAsc(userId, startAt, finishAt);
 
@@ -79,8 +76,7 @@ public class ScheduleService {
 
     public List<ScheduleCountDto> countSchedules(Long userId, LocalDateTime startAt, LocalDateTime finishAt) {
 
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new GlobalException(UserExceptionCode.USER_NOT_FOUND));
+        User user = userService.read(userId);
 
         List<Schedule> mySchedules = scheduleRepository.findByUserIdAndStartAtBetweenOrderByStartAtAsc(userId, startAt, finishAt);
 
@@ -116,8 +112,7 @@ public class ScheduleService {
         Schedule schedule = scheduleRepository.findById(scheduleId)
                 .orElseThrow(() -> new GlobalException(ScheduleExceptionCode.SCHEDULE_NOT_FOUND));
 
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new GlobalException(UserExceptionCode.USER_NOT_FOUND));
+        User user = userService.read(userId);
 
         validate(scheduleRequestDto.startAt(), scheduleRequestDto.finishAt());
 

--- a/src/main/java/com/example/holing/bounded_context/schedule/service/ScheduleService.java
+++ b/src/main/java/com/example/holing/bounded_context/schedule/service/ScheduleService.java
@@ -57,10 +57,16 @@ public class ScheduleService {
                 .orElseThrow(() -> new GlobalException(UserExceptionCode.USER_NOT_FOUND));
 
         List<Schedule> mySchedules = scheduleRepository.findByUserIdAndStartAtBetweenOrderByStartAtAsc(userId, startAt, finishAt);
-        List<Schedule> mateSchedules = scheduleRepository.findByUserIdAndStartAtBetweenOrderByStartAtAsc(user.getMate().getId(), startAt, finishAt);
 
-        mySchedules.addAll(mateSchedules);
+        // 짝꿍이 있는 경우, 짝꿍의 일정도 추가한다.
+        if (user.getMate() != null) {
+            List<Schedule> mateSchedules = scheduleRepository.findByUserIdAndStartAtBetweenOrderByStartAtAsc(user.getMate().getId(), startAt, finishAt);
+            mySchedules.addAll(mateSchedules);
+        }
 
+        if (mySchedules.isEmpty()) {
+            throw new GlobalException(ScheduleExceptionCode.SCHEDULE_NOT_FOUND);
+        }
         return mySchedules.stream()
                 .map(ScheduleResponseDto::fromEntity)
                 .collect(Collectors.toList());

--- a/src/main/java/com/example/holing/bounded_context/schedule/service/ScheduleService.java
+++ b/src/main/java/com/example/holing/bounded_context/schedule/service/ScheduleService.java
@@ -39,8 +39,6 @@ public class ScheduleService {
         Schedule schedule = scheduleRequestDto.toEntity();
 
         schedule.setUser(user);
-        user.getSchedules().add(schedule);
-
         scheduleRepository.save(schedule);
 
         return ScheduleResponseDto.fromEntity(schedule);
@@ -74,7 +72,7 @@ public class ScheduleService {
 
         schedule.update(
                 scheduleRequestDto.title(),
-                scheduleRequestDto.place(),
+                scheduleRequestDto.content(),
                 scheduleRequestDto.startAt(),
                 scheduleRequestDto.finishAt()
         );
@@ -94,7 +92,6 @@ public class ScheduleService {
         User user = userRepository.findById(schedule.getUser().getId())
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다"));
 
-        user.getSchedules().remove(schedule);
         scheduleRepository.deleteById(scheduleId);
     }
 

--- a/src/main/java/com/example/holing/bounded_context/schedule/service/ScheduleService.java
+++ b/src/main/java/com/example/holing/bounded_context/schedule/service/ScheduleService.java
@@ -10,7 +10,7 @@ import com.example.holing.bounded_context.user.entity.User;
 import com.example.holing.bounded_context.user.exception.UserExceptionCode;
 import com.example.holing.bounded_context.user.repository.UserRepository;
 import jakarta.transaction.Transactional;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
@@ -19,13 +19,12 @@ import java.util.stream.Collectors;
 
 @Service
 @Transactional
+@RequiredArgsConstructor
 public class ScheduleService {
 
-    @Autowired
-    private ScheduleRepository scheduleRepository;
+    private final ScheduleRepository scheduleRepository;
 
-    @Autowired
-    private UserRepository userRepository;
+    private final UserRepository userRepository;
 
     /**
      * 일정 등록


### PR DESCRIPTION
### 🔥 작업 동기 및 이슈

- close: #46 
- close: #48 
- close: #49 
- close: #50 
- close: #51 
- close: #52 
- close: #53 
- close: #54 

### 🛠️ 변경 사항

- Schdule 일부 클래스에서 DI 시 필드 주입 방식을 사용했는데 생성자 주입으로 수정
- 기존의 place 필드명을 content로 수정
- Swagger 및 Custom Exception 추가
- 짝궁의 일정도 함께 조회 할 수 있도록 반영 (일정 개수에도 포함)

### ☑️ 테스트 결과

- 일정 조회 시 date에서 해당 월 전체의 일정 개수를 조회합니다. (날짜순으로 반환)
![image](https://github.com/user-attachments/assets/729489ad-6965-4900-8ecb-5c5c4f0bbd09)
![image](https://github.com/user-attachments/assets/453b87da-0797-4f08-b675-1df8600b1051)
7월 17일의 일정 5개, 7월 19일의 일정 2개가 정확하게 카운팅 됩니다.

### 🌟 참고사항

- Swagger와 Exception의 경우, 같이 있을 때 작성한 부분을 참고해서 추가했습니다.
  - 어색한 부분이나 추가해야할 부분이 있다면 추후 API 개발이 어느 정도 된 후  수정 및 추가하도록 하겠습니다. 😄 
- JPA의 장점을 활용하고자 했는데 일정 조회의 경우 기간이 포함되기 때문에 부득이하게 필요하다고 생각되는 부분에 모두 사용한 것 같은데 혹시 수정할 부분이 있다면 말씀해주세요!