### PR TITLE
Report 조회 및 생성 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,8 @@ dependencies {
 
     //swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.4.0'
+
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/holing/bounded_context/report/api/ReportApi.java
+++ b/src/main/java/com/example/holing/bounded_context/report/api/ReportApi.java
@@ -1,0 +1,60 @@
+package com.example.holing.bounded_context.report.api;
+
+import com.example.holing.bounded_context.report.dto.ReportDetailResponseDto;
+import com.example.holing.bounded_context.report.dto.ReportRequestDto;
+import com.example.holing.bounded_context.report.dto.ReportScoreResponseDto;
+import com.example.holing.bounded_context.report.dto.ReportSummaryResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Size;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import java.util.List;
+
+@Tag(name = "[리포트 관련 API]", description = "리포트 조회 및 생성 API")
+public interface ReportApi {
+    @GetMapping("/user/me/reports/score")
+    @Operation(summary = "리포트 점수 조회", description = """
+            사용자가 본인의 리포트 점수들을 조회하기 위한 API 입니다
+            리포트의 태그와 점수 목록을 반환합니다.
+            """)
+    ResponseEntity<List<ReportScoreResponseDto>> score(HttpServletRequest request);
+
+    @GetMapping("/user/mate/reports/score")
+    @Operation(summary = "짝꿍 리포트 점수 조회", description = """
+            사용자가 짝꿍의 리포트 점수들을 조회하기 위한 API 입니다
+            리포트의 태그와 점수 목록을 반환합니다.
+            """)
+    public ResponseEntity<List<ReportScoreResponseDto>> mateScore(HttpServletRequest request);
+
+    @GetMapping("/user/me/reports/summary")
+    @Operation(summary = "본인 리포트 요약 조회", description = """
+            사용자가 본인의 리포트 요약들을 조회하기 위한 API 입니다
+            테스트 결과 점수가 가장 높은 증상의 솔루션 제목을 반환합니다.
+            """)
+    public ResponseEntity<List<ReportSummaryResponseDto>> summary(HttpServletRequest request);
+
+    @GetMapping("/user/mate/reports/summary")
+    @Operation(summary = "짝꿍 리포트 요약 조회", description = """
+            사용자가 짝꿍의 리포트 요약들을 조회하기 위한 API 입니다
+            테스트 결과 점수가 가장 높은 증상의 솔루션 제목을 반환합니다.
+            """)
+    public ResponseEntity<List<ReportSummaryResponseDto>> mateSummary(HttpServletRequest request);
+
+    @GetMapping("/reports/{reportId}")
+    @Operation(summary = "리포트 상세 조회", description = "사용자가 리포트를 상세 조회하기 위한 API 입니다")
+    public ResponseEntity<ReportDetailResponseDto> read(HttpServletRequest request, @PathVariable Long reportId);
+
+    @PostMapping("/reports")
+    @Operation(summary = "리포트 생성", description = """
+            사용자의 증상 테스트 결과로 리포트를 생성하기 위한 API 입니다.
+            점수와 사용자 입력 항목을 받습니다. 사용자 입력 항목이 없는 경우 빈 문자열을 입력합니다. 
+            """)
+    public ResponseEntity<String> create(HttpServletRequest request, @RequestBody @Valid @Size(min = 6, max = 6) List<ReportRequestDto> reportRequestDtos);
+}

--- a/src/main/java/com/example/holing/bounded_context/report/controller/ReportController.java
+++ b/src/main/java/com/example/holing/bounded_context/report/controller/ReportController.java
@@ -13,6 +13,7 @@ import com.example.holing.bounded_context.user.entity.User;
 import com.example.holing.bounded_context.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.Size;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -78,7 +79,7 @@ public class ReportController {
 
     @PostMapping("")
     @Operation(summary = "리포트 생성", description = "사용자가 자가 테스트를 하여 리포트를 생성하기 위한 API 입니다.")
-    public ResponseEntity<String> create(HttpServletRequest request, @RequestBody @Size(min = 6, max = 6) List<ReportRequestDto> reportRequestDtos) {
+    public ResponseEntity<String> create(HttpServletRequest request, @RequestBody @Valid @Size(min = 6, max = 6) List<ReportRequestDto> reportRequestDtos) {
         String accessToken = jwtProvider.getToken(request);
         String userId = jwtProvider.getUserId(accessToken);
 

--- a/src/main/java/com/example/holing/bounded_context/report/controller/ReportController.java
+++ b/src/main/java/com/example/holing/bounded_context/report/controller/ReportController.java
@@ -1,0 +1,89 @@
+package com.example.holing.bounded_context.report.controller;
+
+import com.example.holing.base.jwt.JwtProvider;
+import com.example.holing.bounded_context.report.dto.ReportDetailResponseDto;
+import com.example.holing.bounded_context.report.dto.ReportRequestDto;
+import com.example.holing.bounded_context.report.dto.ReportScoreResponseDto;
+import com.example.holing.bounded_context.report.dto.ReportSummaryResponseDto;
+import com.example.holing.bounded_context.report.entity.Report;
+import com.example.holing.bounded_context.report.entity.UserReport;
+import com.example.holing.bounded_context.report.service.ReportService;
+import com.example.holing.bounded_context.report.service.UserReportService;
+import com.example.holing.bounded_context.user.entity.User;
+import com.example.holing.bounded_context.user.service.UserService;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.constraints.Size;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@Slf4j
+@RequiredArgsConstructor
+@RequestMapping("/report")
+public class ReportController {
+
+    private final UserService userService;
+    private final ReportService reportService;
+    private final UserReportService userReportService;
+    private final JwtProvider jwtProvider;
+
+    @GetMapping("/score")
+    @Operation(summary = "리포트 점수 조회", description = "사용자가 리포트들의 점수를 조회하기 위한 API 입니다")
+    public ResponseEntity<List<ReportScoreResponseDto>> score(HttpServletRequest request) {
+        String accessToken = jwtProvider.getToken(request);
+        String userId = jwtProvider.getUserId(accessToken);
+
+        User user = userService.read(Long.parseLong(userId));
+
+        List<UserReport> reports = userReportService.readAllWithReportByUser(user);
+        List<ReportScoreResponseDto> response = reports.stream().map(ReportScoreResponseDto::fromEntity).toList();
+        return ResponseEntity.ok().body(response);
+    }
+
+    @GetMapping("/summary")
+    @Operation(summary = "리포트 요약 조회", description = "사용자가 리포트들의 요약을 조회하기 위한 API 입니다")
+    public ResponseEntity<List<ReportSummaryResponseDto>> summary(HttpServletRequest request) {
+        String accessToken = jwtProvider.getToken(request);
+        String userId = jwtProvider.getUserId(accessToken);
+
+        User user = userService.read(Long.parseLong(userId));
+
+        List<ReportSummaryResponseDto> response = userReportService.readAllByUser(user).stream()
+                .map(ReportSummaryResponseDto::fromEntity).toList();
+        return ResponseEntity.ok().body(response);
+    }
+
+    @GetMapping("/{reportId}")
+    @Operation(summary = "리포트 상세 조회", description = "사용자가 리포트를 상세 조회하기 위한 API 입니다")
+    public ResponseEntity<ReportDetailResponseDto> read(HttpServletRequest request, @PathVariable Long reportId) {
+        String accessToken = jwtProvider.getToken(request);
+        String userId = jwtProvider.getUserId(accessToken);
+
+        User user = userService.read(Long.parseLong(userId));
+
+        UserReport userReport = userReportService.readWithReportAndSolutionById(reportId);
+        ReportDetailResponseDto response = ReportDetailResponseDto.fromEntity(userReport);
+        return ResponseEntity.ok().body(response);
+    }
+
+    @PostMapping("")
+    @Operation(summary = "리포트 생성", description = "사용자가 자가 테스트를 하여 리포트를 생성하기 위한 API 입니다.")
+    public ResponseEntity<String> create(HttpServletRequest request, @RequestBody @Size(min = 6, max = 6) List<ReportRequestDto> reportRequestDtos) {
+        String accessToken = jwtProvider.getToken(request);
+        String userId = jwtProvider.getUserId(accessToken);
+
+        User user = userService.read(Long.parseLong(userId));
+        List<Report> reports = reportService.create(user, reportRequestDtos);
+        return ResponseEntity.ok().body("리포트가 성공적으로 작성되었습니다.");
+    }
+}

--- a/src/main/java/com/example/holing/bounded_context/report/controller/ReportController.java
+++ b/src/main/java/com/example/holing/bounded_context/report/controller/ReportController.java
@@ -1,6 +1,7 @@
 package com.example.holing.bounded_context.report.controller;
 
 import com.example.holing.base.jwt.JwtProvider;
+import com.example.holing.bounded_context.report.api.ReportApi;
 import com.example.holing.bounded_context.report.dto.ReportDetailResponseDto;
 import com.example.holing.bounded_context.report.dto.ReportRequestDto;
 import com.example.holing.bounded_context.report.dto.ReportScoreResponseDto;
@@ -11,16 +12,13 @@ import com.example.holing.bounded_context.report.service.ReportService;
 import com.example.holing.bounded_context.report.service.UserReportService;
 import com.example.holing.bounded_context.user.entity.User;
 import com.example.holing.bounded_context.user.service.UserService;
-import io.swagger.v3.oas.annotations.Operation;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Size;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -29,15 +27,13 @@ import java.util.List;
 @RestController
 @Slf4j
 @RequiredArgsConstructor
-public class ReportController {
+public class ReportController implements ReportApi {
 
     private final UserService userService;
     private final ReportService reportService;
     private final UserReportService userReportService;
     private final JwtProvider jwtProvider;
 
-    @GetMapping("/user/me/reports/score")
-    @Operation(summary = "리포트 점수 조회", description = "사용자가 본인의 리포트 점수들을 조회하기 위한 API 입니다")
     public ResponseEntity<List<ReportScoreResponseDto>> score(HttpServletRequest request) {
         String accessToken = jwtProvider.getToken(request);
         String userId = jwtProvider.getUserId(accessToken);
@@ -49,8 +45,6 @@ public class ReportController {
         return ResponseEntity.ok().body(response);
     }
 
-    @GetMapping("/user/mate/reports/score")
-    @Operation(summary = "짝꿍 리포트 점수 조회", description = "사용자가 짝꿍의 리포트 점수들을 조회하기 위한 API 입니다")
     public ResponseEntity<List<ReportScoreResponseDto>> mateScore(HttpServletRequest request) {
         String accessToken = jwtProvider.getToken(request);
         String userId = jwtProvider.getUserId(accessToken);
@@ -63,8 +57,6 @@ public class ReportController {
         return ResponseEntity.ok().body(response);
     }
 
-    @GetMapping("/user/me/reports/summary")
-    @Operation(summary = "본인 리포트 요약 조회", description = "사용자가 본인의 리포트 요약들을 조회하기 위한 API 입니다")
     public ResponseEntity<List<ReportSummaryResponseDto>> summary(HttpServletRequest request) {
         String accessToken = jwtProvider.getToken(request);
         String userId = jwtProvider.getUserId(accessToken);
@@ -76,8 +68,6 @@ public class ReportController {
         return ResponseEntity.ok().body(response);
     }
 
-    @GetMapping("/user/mate/reports/summary")
-    @Operation(summary = "짝꿍 리포트 요약 조회", description = "사용자가 짝꿍의 리포트 요약들을 조회하기 위한 API 입니다")
     public ResponseEntity<List<ReportSummaryResponseDto>> mateSummary(HttpServletRequest request) {
         String accessToken = jwtProvider.getToken(request);
         String userId = jwtProvider.getUserId(accessToken);
@@ -90,8 +80,6 @@ public class ReportController {
         return ResponseEntity.ok().body(response);
     }
 
-    @GetMapping("/reports/{reportId}")
-    @Operation(summary = "리포트 상세 조회", description = "사용자가 리포트를 상세 조회하기 위한 API 입니다")
     public ResponseEntity<ReportDetailResponseDto> read(HttpServletRequest request, @PathVariable Long reportId) {
         String accessToken = jwtProvider.getToken(request);
         String userId = jwtProvider.getUserId(accessToken);
@@ -103,8 +91,6 @@ public class ReportController {
         return ResponseEntity.ok().body(response);
     }
 
-    @PostMapping("/reports")
-    @Operation(summary = "리포트 생성", description = "사용자가 자가 테스트를 하여 리포트를 생성하기 위한 API 입니다.")
     public ResponseEntity<String> create(HttpServletRequest request, @RequestBody @Valid @Size(min = 6, max = 6) List<ReportRequestDto> reportRequestDtos) {
         String accessToken = jwtProvider.getToken(request);
         String userId = jwtProvider.getUserId(accessToken);

--- a/src/main/java/com/example/holing/bounded_context/report/dto/ReportDetailDto.java
+++ b/src/main/java/com/example/holing/bounded_context/report/dto/ReportDetailDto.java
@@ -5,14 +5,14 @@ import com.example.holing.bounded_context.report.entity.Report;
 public record ReportDetailDto(
         int score,
         String tagName,
-        String content,
+        String additional,
         SolutionDto solution
 ) {
     public static ReportDetailDto fromEntity(Report report) {
         return new ReportDetailDto(
                 report.getScore(),
                 report.getTag().getName(),
-                report.getContent(),
+                report.getAdditional(),
                 SolutionDto.fromEntity(report.getSolution())
         );
     }

--- a/src/main/java/com/example/holing/bounded_context/report/dto/ReportDetailDto.java
+++ b/src/main/java/com/example/holing/bounded_context/report/dto/ReportDetailDto.java
@@ -1,18 +1,21 @@
 package com.example.holing.bounded_context.report.dto;
 
 import com.example.holing.bounded_context.report.entity.Report;
+import com.example.holing.bounded_context.survey.entity.Solution;
 
 public record ReportDetailDto(
         int score,
         String tagName,
-        String additional,
+        String title,
         SolutionDto solution
 ) {
     public static ReportDetailDto fromEntity(Report report) {
+        String additional = report.getAdditional();
+        Solution solution = report.getSolution();
         return new ReportDetailDto(
                 report.getScore(),
                 report.getTag().getName(),
-                report.getAdditional(),
+                solution.getIsAdditional() ? additional + solution.getTitle() : solution.getTitle(),
                 SolutionDto.fromEntity(report.getSolution())
         );
     }

--- a/src/main/java/com/example/holing/bounded_context/report/dto/ReportDetailDto.java
+++ b/src/main/java/com/example/holing/bounded_context/report/dto/ReportDetailDto.java
@@ -2,10 +2,14 @@ package com.example.holing.bounded_context.report.dto;
 
 import com.example.holing.bounded_context.report.entity.Report;
 import com.example.holing.bounded_context.survey.entity.Solution;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 public record ReportDetailDto(
+        @Schema(description = "점수", example = "5")
         int score,
+        @Schema(description = "태그 이름", example = "SLEEP_PROBLEM")
         String tagName,
+        @Schema(description = "제목", example = "무릎의 관절통증에 가장 큰 어려움을 겪어요")
         String title,
         SolutionDto solution
 ) {

--- a/src/main/java/com/example/holing/bounded_context/report/dto/ReportDetailDto.java
+++ b/src/main/java/com/example/holing/bounded_context/report/dto/ReportDetailDto.java
@@ -1,0 +1,19 @@
+package com.example.holing.bounded_context.report.dto;
+
+import com.example.holing.bounded_context.report.entity.Report;
+
+public record ReportDetailDto(
+        int score,
+        String tagName,
+        String content,
+        SolutionDto solution
+) {
+    public static ReportDetailDto fromEntity(Report report) {
+        return new ReportDetailDto(
+                report.getScore(),
+                report.getTag().getName(),
+                report.getContent(),
+                SolutionDto.fromEntity(report.getSolution())
+        );
+    }
+}

--- a/src/main/java/com/example/holing/bounded_context/report/dto/ReportDetailResponseDto.java
+++ b/src/main/java/com/example/holing/bounded_context/report/dto/ReportDetailResponseDto.java
@@ -3,16 +3,21 @@ package com.example.holing.bounded_context.report.dto;
 import com.example.holing.bounded_context.report.entity.UserReport;
 
 import java.time.LocalDateTime;
+import java.time.temporal.WeekFields;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Locale;
 
 public record ReportDetailResponseDto(
-        LocalDateTime createdAt,
+        int month,
+        int weekOfMonth,
         List<ReportDetailDto> reportList
 ) {
     public static ReportDetailResponseDto fromEntity(UserReport userReport) {
+        LocalDateTime createdAt = userReport.getCreatedAt();
         return new ReportDetailResponseDto(
-                userReport.getCreatedAt(),
+                createdAt.getMonthValue(),
+                createdAt.get(WeekFields.of(Locale.getDefault()).weekOfMonth()),
                 userReport.getReports().stream()
                         .map(ReportDetailDto::fromEntity)
                         .sorted(Comparator.comparingInt(ReportDetailDto::score).reversed())

--- a/src/main/java/com/example/holing/bounded_context/report/dto/ReportDetailResponseDto.java
+++ b/src/main/java/com/example/holing/bounded_context/report/dto/ReportDetailResponseDto.java
@@ -1,6 +1,7 @@
 package com.example.holing.bounded_context.report.dto;
 
 import com.example.holing.bounded_context.report.entity.UserReport;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 import java.time.temporal.WeekFields;
@@ -9,7 +10,9 @@ import java.util.List;
 import java.util.Locale;
 
 public record ReportDetailResponseDto(
+        @Schema(description = "월", example = "7")
         int month,
+        @Schema(description = "주차", example = "1")
         int weekOfMonth,
         List<ReportDetailDto> reportList
 ) {

--- a/src/main/java/com/example/holing/bounded_context/report/dto/ReportDetailResponseDto.java
+++ b/src/main/java/com/example/holing/bounded_context/report/dto/ReportDetailResponseDto.java
@@ -1,0 +1,22 @@
+package com.example.holing.bounded_context.report.dto;
+
+import com.example.holing.bounded_context.report.entity.UserReport;
+
+import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.List;
+
+public record ReportDetailResponseDto(
+        LocalDateTime createdAt,
+        List<ReportDetailDto> reportList
+) {
+    public static ReportDetailResponseDto fromEntity(UserReport userReport) {
+        return new ReportDetailResponseDto(
+                userReport.getCreatedAt(),
+                userReport.getReports().stream()
+                        .map(ReportDetailDto::fromEntity)
+                        .sorted(Comparator.comparingInt(ReportDetailDto::score).reversed())
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/com/example/holing/bounded_context/report/dto/ReportRequestDto.java
+++ b/src/main/java/com/example/holing/bounded_context/report/dto/ReportRequestDto.java
@@ -1,13 +1,17 @@
 package com.example.holing.bounded_context.report.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 
 public record ReportRequestDto(
         @Min(1) @Max(6)
+        @Schema(description = "태그 id(1에서 6사이의 값)", example = "1")
         Long tagId,
         @Min(0) @Max(18)
+        @Schema(description = "점수(0에서 18사이의 값)", example = "15")
         int score,
+        @Schema(description = "사용자 추가 필드(사용자 추가 설문이 존재하지 않는 경우 빈 문자열)", example = "안면 홍조")
         String additional
 ) {
 

--- a/src/main/java/com/example/holing/bounded_context/report/dto/ReportRequestDto.java
+++ b/src/main/java/com/example/holing/bounded_context/report/dto/ReportRequestDto.java
@@ -1,0 +1,14 @@
+package com.example.holing.bounded_context.report.dto;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+
+public record ReportRequestDto(
+        @Min(1) @Max(6)
+        Long tagId,
+        @Min(0) @Max(18)
+        int score,
+        String content
+) {
+
+}

--- a/src/main/java/com/example/holing/bounded_context/report/dto/ReportRequestDto.java
+++ b/src/main/java/com/example/holing/bounded_context/report/dto/ReportRequestDto.java
@@ -8,7 +8,7 @@ public record ReportRequestDto(
         Long tagId,
         @Min(0) @Max(18)
         int score,
-        String content
+        String additional
 ) {
 
 }

--- a/src/main/java/com/example/holing/bounded_context/report/dto/ReportScoreDto.java
+++ b/src/main/java/com/example/holing/bounded_context/report/dto/ReportScoreDto.java
@@ -1,9 +1,12 @@
 package com.example.holing.bounded_context.report.dto;
 
 import com.example.holing.bounded_context.report.entity.Report;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 public record ReportScoreDto(
+        @Schema(description = "점수", example = "5")
         int score,
+        @Schema(description = "태그 이름", example = "SLEEP_PROBLEM")
         String tagName
 ) {
     public static ReportScoreDto fromEntity(Report report) {

--- a/src/main/java/com/example/holing/bounded_context/report/dto/ReportScoreDto.java
+++ b/src/main/java/com/example/holing/bounded_context/report/dto/ReportScoreDto.java
@@ -1,0 +1,15 @@
+package com.example.holing.bounded_context.report.dto;
+
+import com.example.holing.bounded_context.report.entity.Report;
+
+public record ReportScoreDto(
+        int score,
+        String tagName
+) {
+    public static ReportScoreDto fromEntity(Report report) {
+        return new ReportScoreDto(
+                report.getScore(),
+                report.getTag().getName()
+        );
+    }
+}

--- a/src/main/java/com/example/holing/bounded_context/report/dto/ReportScoreResponseDto.java
+++ b/src/main/java/com/example/holing/bounded_context/report/dto/ReportScoreResponseDto.java
@@ -3,15 +3,20 @@ package com.example.holing.bounded_context.report.dto;
 import com.example.holing.bounded_context.report.entity.UserReport;
 
 import java.time.LocalDateTime;
+import java.time.temporal.WeekFields;
 import java.util.List;
+import java.util.Locale;
 
 public record ReportScoreResponseDto(
-        LocalDateTime createdAt,
+        int month,
+        int weekOfMonth,
         List<ReportScoreDto> reportList
 ) {
     public static ReportScoreResponseDto fromEntity(UserReport userReport) {
+        LocalDateTime createdAt = userReport.getCreatedAt();
         return new ReportScoreResponseDto(
-                userReport.getCreatedAt(),
+                createdAt.getMonthValue(),
+                createdAt.get(WeekFields.of(Locale.getDefault()).weekOfMonth()),
                 userReport.getReports().stream()
                         .map(ReportScoreDto::fromEntity).toList()
         );

--- a/src/main/java/com/example/holing/bounded_context/report/dto/ReportScoreResponseDto.java
+++ b/src/main/java/com/example/holing/bounded_context/report/dto/ReportScoreResponseDto.java
@@ -1,0 +1,19 @@
+package com.example.holing.bounded_context.report.dto;
+
+import com.example.holing.bounded_context.report.entity.UserReport;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record ReportScoreResponseDto(
+        LocalDateTime createdAt,
+        List<ReportScoreDto> reportList
+) {
+    public static ReportScoreResponseDto fromEntity(UserReport userReport) {
+        return new ReportScoreResponseDto(
+                userReport.getCreatedAt(),
+                userReport.getReports().stream()
+                        .map(ReportScoreDto::fromEntity).toList()
+        );
+    }
+}

--- a/src/main/java/com/example/holing/bounded_context/report/dto/ReportScoreResponseDto.java
+++ b/src/main/java/com/example/holing/bounded_context/report/dto/ReportScoreResponseDto.java
@@ -1,6 +1,7 @@
 package com.example.holing.bounded_context.report.dto;
 
 import com.example.holing.bounded_context.report.entity.UserReport;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 import java.time.temporal.WeekFields;
@@ -8,7 +9,9 @@ import java.util.List;
 import java.util.Locale;
 
 public record ReportScoreResponseDto(
+        @Schema(description = "월", example = "7")
         int month,
+        @Schema(description = "주차", example = "1")
         int weekOfMonth,
         List<ReportScoreDto> reportList
 ) {

--- a/src/main/java/com/example/holing/bounded_context/report/dto/ReportSummaryResponseDto.java
+++ b/src/main/java/com/example/holing/bounded_context/report/dto/ReportSummaryResponseDto.java
@@ -3,6 +3,7 @@ package com.example.holing.bounded_context.report.dto;
 import com.example.holing.bounded_context.report.entity.Report;
 import com.example.holing.bounded_context.report.entity.UserReport;
 import com.example.holing.bounded_context.survey.entity.Solution;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 import java.time.temporal.WeekFields;
@@ -10,9 +11,13 @@ import java.util.Comparator;
 import java.util.Locale;
 
 public record ReportSummaryResponseDto(
+        @Schema(description = "리포트 id", example = "1")
         Long id,
+        @Schema(description = "월", example = "7")
         int month,
+        @Schema(description = "주차", example = "1")
         int weekOfMonth,
+        @Schema(description = "제목", example = "무릎의 관절통증에 가장 큰 어려움을 겪어요")
         String title
 ) {
     public static ReportSummaryResponseDto fromEntity(UserReport userReport) {

--- a/src/main/java/com/example/holing/bounded_context/report/dto/ReportSummaryResponseDto.java
+++ b/src/main/java/com/example/holing/bounded_context/report/dto/ReportSummaryResponseDto.java
@@ -2,22 +2,32 @@ package com.example.holing.bounded_context.report.dto;
 
 import com.example.holing.bounded_context.report.entity.Report;
 import com.example.holing.bounded_context.report.entity.UserReport;
+import com.example.holing.bounded_context.survey.entity.Solution;
 
 import java.time.LocalDateTime;
+import java.time.temporal.WeekFields;
 import java.util.Comparator;
+import java.util.Locale;
 
 public record ReportSummaryResponseDto(
         Long id,
-        LocalDateTime createdAt,
+        int month,
+        int weekOfMonth,
         String title
 ) {
     public static ReportSummaryResponseDto fromEntity(UserReport userReport) {
+        LocalDateTime createdAt = userReport.getCreatedAt();
+        Report report = userReport.getReports().stream()
+                .max(Comparator.comparingInt(Report::getScore))
+                .get();
+        String additional = report.getAdditional();
+        Solution solution = report.getSolution();
+
         return new ReportSummaryResponseDto(
                 userReport.getId(),
-                userReport.getCreatedAt(),
-                userReport.getReports().stream()
-                        .max(Comparator.comparingInt(Report::getScore))
-                        .get().getSolution().getTitle()
+                createdAt.getMonthValue(),
+                createdAt.get(WeekFields.of(Locale.getDefault()).weekOfMonth()),
+                solution.getIsAdditional() ? additional + solution.getTitle() : solution.getTitle()
         );
     }
 }

--- a/src/main/java/com/example/holing/bounded_context/report/dto/ReportSummaryResponseDto.java
+++ b/src/main/java/com/example/holing/bounded_context/report/dto/ReportSummaryResponseDto.java
@@ -1,0 +1,23 @@
+package com.example.holing.bounded_context.report.dto;
+
+import com.example.holing.bounded_context.report.entity.Report;
+import com.example.holing.bounded_context.report.entity.UserReport;
+
+import java.time.LocalDateTime;
+import java.util.Comparator;
+
+public record ReportSummaryResponseDto(
+        Long id,
+        LocalDateTime createdAt,
+        String title
+) {
+    public static ReportSummaryResponseDto fromEntity(UserReport userReport) {
+        return new ReportSummaryResponseDto(
+                userReport.getId(),
+                userReport.getCreatedAt(),
+                userReport.getReports().stream()
+                        .max(Comparator.comparingInt(Report::getScore))
+                        .get().getSolution().getTitle()
+        );
+    }
+}

--- a/src/main/java/com/example/holing/bounded_context/report/dto/SolutionDto.java
+++ b/src/main/java/com/example/holing/bounded_context/report/dto/SolutionDto.java
@@ -3,7 +3,6 @@ package com.example.holing.bounded_context.report.dto;
 import com.example.holing.bounded_context.survey.entity.Solution;
 
 public record SolutionDto(
-        String title,
         String summary,
         String content1,
         String content2,
@@ -11,7 +10,6 @@ public record SolutionDto(
 ) {
     public static SolutionDto fromEntity(Solution solution) {
         return new SolutionDto(
-                solution.getTitle(),
                 solution.getSummary(),
                 solution.getContent1(),
                 solution.getContent2(),

--- a/src/main/java/com/example/holing/bounded_context/report/dto/SolutionDto.java
+++ b/src/main/java/com/example/holing/bounded_context/report/dto/SolutionDto.java
@@ -1,11 +1,16 @@
 package com.example.holing.bounded_context.report.dto;
 
 import com.example.holing.bounded_context.survey.entity.Solution;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 public record SolutionDto(
+        @Schema(description = "요약", example = "갱년기 동안 신체 통증은 여성의 경우 에스트로겐 감소가, 남성의 경우 테스토스테론 감소가 관절의 염증을 증가시키고 근육의 유연성을 감소시켜 유발될 수 있어요. 이러한 통증은 일상 생활의 질을 크게 저하시킬 수 있어요.")
         String summary,
+        @Schema(description = "콘텐츠1", example = "전문의의 진단과 치료를 받아보세요. 약물 치료나 특정 운동 요법을 통해 통증을 관리하세요. 또한, 통증이 심할 때는 무리하지 않도록 주의하세요.")
         String content1,
+        @Schema(description = "콘텐츠2", example = "MSM(메틸설포닐메탄)과 보스웰리아를 섭취해보세요. MSM은 통증 완화에 도움을 주고, 보스웰리아는 항염증 작용이 있어요.")
         String content2,
+        @Schema(description = "콘텐츠3", example = "녹색 잎채소와 아보카도를 드셔보세요. 녹색 잎채소는 항산화 성분이 풍부하고, 아보카도는 항염증 작용을 도와줘요.")
         String content3
 ) {
     public static SolutionDto fromEntity(Solution solution) {

--- a/src/main/java/com/example/holing/bounded_context/report/dto/SolutionDto.java
+++ b/src/main/java/com/example/holing/bounded_context/report/dto/SolutionDto.java
@@ -1,0 +1,22 @@
+package com.example.holing.bounded_context.report.dto;
+
+import com.example.holing.bounded_context.survey.entity.Solution;
+
+public record SolutionDto(
+        String title,
+        String summary,
+        String content1,
+        String content2,
+        String content3
+) {
+    public static SolutionDto fromEntity(Solution solution) {
+        return new SolutionDto(
+                solution.getTitle(),
+                solution.getSummary(),
+                solution.getContent1(),
+                solution.getContent2(),
+                solution.getContent3()
+        );
+    }
+
+}

--- a/src/main/java/com/example/holing/bounded_context/report/entity/Report.java
+++ b/src/main/java/com/example/holing/bounded_context/report/entity/Report.java
@@ -1,0 +1,53 @@
+package com.example.holing.bounded_context.report.entity;
+
+import com.example.holing.bounded_context.survey.entity.Solution;
+import com.example.holing.bounded_context.survey.entity.Tag;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Report {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "solution_id", nullable = false)
+    private Solution solution;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "tag_id", nullable = false)
+    private Tag tag;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_report_id", nullable = false)
+    private UserReport userReport;
+
+    @Column(nullable = false)
+    private int score;
+
+    private String content;
+
+    @Builder
+    public Report(Long id, Solution solution, Tag tag, UserReport userReport, int score, String content) {
+        this.id = id;
+        this.solution = solution;
+        this.tag = tag;
+        this.userReport = userReport;
+        this.score = score;
+        this.content = content;
+    }
+}

--- a/src/main/java/com/example/holing/bounded_context/report/entity/Report.java
+++ b/src/main/java/com/example/holing/bounded_context/report/entity/Report.java
@@ -39,15 +39,15 @@ public class Report {
     @Column(nullable = false)
     private int score;
 
-    private String content;
+    private String additional;
 
     @Builder
-    public Report(Long id, Solution solution, Tag tag, UserReport userReport, int score, String content) {
+    public Report(Long id, Solution solution, Tag tag, UserReport userReport, int score, String additional) {
         this.id = id;
         this.solution = solution;
         this.tag = tag;
         this.userReport = userReport;
         this.score = score;
-        this.content = content;
+        this.additional = additional;
     }
 }

--- a/src/main/java/com/example/holing/bounded_context/report/entity/UserReport.java
+++ b/src/main/java/com/example/holing/bounded_context/report/entity/UserReport.java
@@ -1,0 +1,43 @@
+package com.example.holing.bounded_context.report.entity;
+
+import com.example.holing.bounded_context.user.entity.User;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserReport {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    private LocalDateTime createdAt;
+
+    @OneToMany(mappedBy = "userReport", fetch = FetchType.LAZY)
+    private List<Report> reports = new ArrayList<>();
+
+    @Builder
+    public UserReport(User user, LocalDateTime createdAt) {
+        this.user = user;
+        this.createdAt = createdAt;
+    }
+}

--- a/src/main/java/com/example/holing/bounded_context/report/repository/ReportRepository.java
+++ b/src/main/java/com/example/holing/bounded_context/report/repository/ReportRepository.java
@@ -1,0 +1,9 @@
+package com.example.holing.bounded_context.report.repository;
+
+import com.example.holing.bounded_context.report.entity.Report;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ReportRepository extends JpaRepository<Report, Long> {
+}

--- a/src/main/java/com/example/holing/bounded_context/report/repository/UserReportRepository.java
+++ b/src/main/java/com/example/holing/bounded_context/report/repository/UserReportRepository.java
@@ -11,9 +11,20 @@ import java.util.Optional;
 
 @Repository
 public interface UserReportRepository extends JpaRepository<UserReport, Long> {
+
+    /**
+     * 사용자의 최신 리포트를 조회하기 위한 쿼리<br>
+     * 리포트 생성 전 최신 리포트의 생성날짜를 조회하기 위한 용도로 사용합니다.
+     *
+     * @param user
+     * @return
+     */
+
+    Optional<UserReport> findFirstByUserOrderByCreatedAtDesc(User user);
+
     /**
      * 사용자의 모든 리포트를 최신순으로 조회하기 위한 쿼리<br>
-     * 리포트 요약에서 리포트와 솔루션을 조회하기 위한 용도로 사용됩니다.
+     * 리포트 요약에서 리포트와 솔루션을 조회하기 위한 용도로 사용합니다.
      *
      * @param user
      * @return
@@ -27,7 +38,7 @@ public interface UserReportRepository extends JpaRepository<UserReport, Long> {
 
     /**
      * 특정 리포트를 조회하기 위한 쿼리<br>
-     * 리포트 상세보기에서 사용자 리포트, 리포트, 솔루션의 정보를 출력하기 위한 용도로 사용됩니다.
+     * 리포트 상세보기에서 사용자 리포트, 리포트, 솔루션의 정보를 출력하기 위한 용도로 사용합니다.
      *
      * @param id
      * @return

--- a/src/main/java/com/example/holing/bounded_context/report/repository/UserReportRepository.java
+++ b/src/main/java/com/example/holing/bounded_context/report/repository/UserReportRepository.java
@@ -1,0 +1,54 @@
+package com.example.holing.bounded_context.report.repository;
+
+import com.example.holing.bounded_context.report.entity.UserReport;
+import com.example.holing.bounded_context.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface UserReportRepository extends JpaRepository<UserReport, Long> {
+    /**
+     * 사용자의 모든 리포트를 최신순으로 조회하기 위한 쿼리<br>
+     * 리포트 요약에서 리포트와 솔루션을 조회하기 위한 용도로 사용됩니다.
+     *
+     * @param user
+     * @return
+     */
+    @Query("select ur from UserReport ur " +
+            "join fetch ur.reports r " +
+            "join fetch r.solution " +
+            "where ur.user = :user " +
+            "order by ur.createdAt desc")
+    List<UserReport> findAllByUser(User user);
+
+    /**
+     * 특정 리포트를 조회하기 위한 쿼리<br>
+     * 리포트 상세보기에서 사용자 리포트, 리포트, 솔루션의 정보를 출력하기 위한 용도로 사용됩니다.
+     *
+     * @param id
+     * @return
+     */
+    @Query("select ur from UserReport ur " +
+            "join fetch ur.reports r " +
+            "join fetch r.solution " +
+            "where ur.id = :id")
+    Optional<UserReport> findWithReportAndSolutionById(Long id);
+
+    /**
+     * 사용자의 모든 리포트를 과거순으로 조회하기 위한 쿼리<br>
+     * 사용자 리포트 그래프에서 사용자의 리포트, 리포트의 정보를 출력하기 위해 사용합니다.
+     *
+     * @param user
+     * @return
+     */
+    @Query("select ur from UserReport ur " +
+            "join fetch ur.reports r " +
+            "where ur.user = :user " +
+            "order by ur.createdAt asc"
+    )
+    List<UserReport> findAllWithReportByUser(User user);
+}

--- a/src/main/java/com/example/holing/bounded_context/report/service/ReportService.java
+++ b/src/main/java/com/example/holing/bounded_context/report/service/ReportService.java
@@ -1,0 +1,60 @@
+package com.example.holing.bounded_context.report.service;
+
+import com.example.holing.bounded_context.report.dto.ReportRequestDto;
+import com.example.holing.bounded_context.report.entity.Report;
+import com.example.holing.bounded_context.report.entity.UserReport;
+import com.example.holing.bounded_context.report.repository.ReportRepository;
+import com.example.holing.bounded_context.survey.entity.Tag;
+import com.example.holing.bounded_context.survey.repository.TagRepository;
+import com.example.holing.bounded_context.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ReportService {
+
+    private final UserReportService userReportService;
+    private final ReportRepository reportRepository;
+    private final TagRepository tagRepository;
+
+    @Transactional
+    public List<Report> create(User user, List<ReportRequestDto> dto) {
+        if (!validateReportByPeriod(user, dto)) throw new IllegalArgumentException("알맞은 검사가 아닙니다.");
+        UserReport userReport = userReportService.create(user);
+
+        List<Tag> tagList = tagRepository.findAllWithSolution();
+        Map<Long, Tag> tagMap = tagList.stream()
+                .collect(Collectors.toMap(Tag::getId, tag -> tag));
+
+        return dto.stream().map(reportRequestDto -> {
+            Tag tag = tagMap.get(reportRequestDto.tagId());
+
+            Report report = Report.builder()
+                    .userReport(userReport)
+                    .score(reportRequestDto.score())
+                    .tag(tag)
+                    .solution(tag.getSolutions().stream()
+                            .filter(solution -> solution.getMinScore() <= reportRequestDto.score())
+                            .min((s1, s2) -> s2.getMinScore() - s1.getMinScore())
+                            .get())
+                    .content(reportRequestDto.content())
+                    .build();
+
+            return reportRepository.save(report);
+        }).toList();
+    }
+
+    public Boolean validateReportByPeriod(User user, List<ReportRequestDto> reportRequestDtos) {
+        ReportRequestDto reportRequestDto = reportRequestDtos.get(5);
+        if (user.getIsPeriod()) {
+            return reportRequestDto.score() != 0;
+        }
+        return reportRequestDto.score() == 0;
+    }
+}

--- a/src/main/java/com/example/holing/bounded_context/report/service/ReportService.java
+++ b/src/main/java/com/example/holing/bounded_context/report/service/ReportService.java
@@ -43,7 +43,7 @@ public class ReportService {
                             .filter(solution -> solution.getMinScore() <= reportRequestDto.score())
                             .min((s1, s2) -> s2.getMinScore() - s1.getMinScore())
                             .get())
-                    .content(reportRequestDto.content())
+                    .additional(reportRequestDto.additional().isEmpty() ? null : reportRequestDto.additional())
                     .build();
 
             return reportRepository.save(report);

--- a/src/main/java/com/example/holing/bounded_context/report/service/UserReportService.java
+++ b/src/main/java/com/example/holing/bounded_context/report/service/UserReportService.java
@@ -1,0 +1,57 @@
+package com.example.holing.bounded_context.report.service;
+
+import com.example.holing.bounded_context.report.entity.Report;
+import com.example.holing.bounded_context.report.entity.UserReport;
+import com.example.holing.bounded_context.report.repository.UserReportRepository;
+import com.example.holing.bounded_context.survey.entity.Tag;
+import com.example.holing.bounded_context.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class UserReportService {
+    private final UserReportRepository userReportRepository;
+
+    public UserReport readWithReportAndSolutionById(Long id) {
+        return userReportRepository.findWithReportAndSolutionById(id)
+                .orElseThrow(() -> new IllegalArgumentException("사용자 리포트를 찾을 수 없습니다."));
+    }
+
+    public List<UserReport> readAllWithReportByUser(User user) {
+        return userReportRepository.findAllWithReportByUser(user);
+    }
+
+    public List<UserReport> readAllByUser(User user) {
+        return userReportRepository.findAllByUser(user);
+    }
+
+    public List<Tag> getUserRecentReportTag(User user) {
+        List<UserReport> userReports = readAllWithReportByUser(user);
+        List<Report> reports = userReports.get(userReports.size() - 1).getReports();
+        return reports.stream().map(Report::getTag).toList();
+    }
+
+    @Transactional
+    public UserReport create(User user) {
+        if (!isWeekInterval(user)) throw new IllegalArgumentException("일주일이 지나지 않았습니다.");
+
+        UserReport userReport = UserReport.builder()
+                .user(user)
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        return userReportRepository.save(userReport);
+    }
+
+    public Boolean isWeekInterval(User user) {
+        Optional<UserReport> userReport = userReportRepository.findFirstByUserOrderByCreatedAtDesc(user);
+        return userReport.map(report -> report.getCreatedAt().isBefore(LocalDateTime.now().minusWeeks(1)))
+                .orElse(true);
+    }
+}

--- a/src/main/java/com/example/holing/bounded_context/survey/entity/Solution.java
+++ b/src/main/java/com/example/holing/bounded_context/survey/entity/Solution.java
@@ -39,4 +39,7 @@ public class Solution {
 
     @ManyToOne(fetch = FetchType.LAZY)
     private Tag tag;
+
+    @Column(nullable = false)
+    private Boolean isAdditional;
 }


### PR DESCRIPTION
### 🔥 작업 동기 및 이슈
1. 사용자가 증상 테스트를 진행한 결과를 바탕으로 리포트를 생성한다. 
2. 사용자는 생성한 모든 리포트의 점수들을 그래프로 조회할 수 있으며 짝꿍의 그래프도 조회할 수 있다
3. 사용자는 생성한 리포트의 솔루션을 요약 조회할 수 있으며 짝꿍의 솔루션 요약도 조회할 수 있다.
4. 사용자는 솔루션을 상세 조회할 수 있다.

- close: #33
- close: #34 
- close: #35 
- close: #36 

### 🛠️ 변경 사항
1. 데이터 베이스 스키마 변경
    - 리포트 생성일을 포함하는 경우 생성일이 중복된다. 따라서 사용자와 리포트 사이에 사용자 리포트 테이블을 추가하여 생성일 필드를 이동했다.
    - 리포트 테이블에 사용자 입력 필드를 추가했다. 대부분의 문항은 객관식으로 점수만을 사용하지만, 사용자가 고른 문항을 기반으로 솔루션 제목을 생성하기 위해서 사용자가 고른 문항의 텍스트를 저장하는 용도로 사용한다.
    - 태그를 enum 으로 선언하지 않고 테이블로 연관관계를 구성하여 태그별 솔루션을 조회하여 사용자 점수를 통해 알맞는 솔루션을 매핑하도록 한다.
2. 주요 로직
    - 지연 로딩과 페치 조인으로 쿼리의 수를 줄인다.
    - 모든 솔루션을 한번에 조회하여 사용자의 점수에 따라 솔루션을 매핑하도록 한다.
    - 사용자 입력 필드를 사용하여 솔루션의 제목을 구성하여 반환하도록 한다.
    - 사용자의 성별이 남성의 경우 월경 태그의 점수가 없지만 점수를 0점으로 저장하고 모든 태그의 점수를 반환하여 성별에 관계 없이 같은 그래프를 조회할 수 있도록 한다. 


### ☑️ 테스트 결과

- 이슈 페이지에서 확인할 수 있습니다.

### 🌟 참고사항

- 설문지에 대한 정보가 부족한 상태에서 테이블을 설계하고 수정해 나가다 보니 서비스에 어떤 지문에 어떤 보기를 골랐다는 정보를 저장하더라도 사용하지 않을 거란 생각이 강했습니다. 또한 다대다 연관관계에 대한 경험이 적고 남은 시간으로 인해 일대다 또는 다대일로 분리할 수 있음에도 시도를 덜 한 탓에 요청값과 테이블 구조가 썩 마음에 들지는 않습니다. 빠르게 개발을 끝낸다면 수정하도록 하겠습니다....

- 상당히 dto 가 많고 엮여 있는데, 테이블을 잘못 설계한 결과로 막무가내 코드가 존재하니 넘어가셔도 좋을 것 같습니다. 세개의 테이블을 조인하다보니 중첩 객체로 인해 내부테이블의 dto와, 외부테이블의 dto가 필요했습니다. dto 만 붙은 것은 내부 테이블의 dto 이고 ReponseDto 가 붙은 것은 클라이언트로 반환되는 dto 입니다. 혹시 다른 방식이 있을 까요?

- 코드를 테이블에 맞추고 테이블을 코드에 맞추면서 작성한 탓에 pr 을 놓치고 있다가 한번에 올리게 되어 한번에 큰 리뷰를 안겨드려 죄송합니다. ㅜㅜ 앞으로는 짧고 굵게 리뷰를 마칠 수 있도록 자주 pr 하겠습니다!  

