### PR TITLE
영양제 생성, 조회 및 수정 API 구현

### DIFF
--- a/src/main/java/com/example/holing/bounded_context/medicine/api/MedicineApi.java
+++ b/src/main/java/com/example/holing/bounded_context/medicine/api/MedicineApi.java
@@ -1,0 +1,37 @@
+package com.example.holing.bounded_context.medicine.api;
+
+import com.example.holing.bounded_context.medicine.dto.MedicineRequestDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Tag(name = "[영양제 관련 API]", description = "영양제 조회, 생성 및 기록 변경 API")
+@RequestMapping("/user/medicines")
+public interface MedicineApi {
+    @PostMapping("")
+    @Operation(summary = "영양제 생성", description = "사용자가 영양제를 생성하기 위한 API 입니다.")
+    ResponseEntity<String> create(HttpServletRequest request, @Valid @RequestBody MedicineRequestDto medicineRequestDto);
+
+    @GetMapping("")
+    @Operation(summary = "영양제 목록 조회", description = """
+            사용자가 영양제 목록을 조회하기 위한 API 입니다.
+            영양제 복용 기록을 통해 상태를 설정합니다.
+            """)
+    public ResponseEntity<?> read(HttpServletRequest request);
+
+    @PostMapping("/{medicineId}/taken")
+    @Operation(summary = "영양제 복용 기록 생성", description = "사용자가 영양제를 복용했다는 기록을 생성하기 위한 API 입니다.")
+    public ResponseEntity<String> taken(HttpServletRequest request, @PathVariable Long medicineId);
+
+    @DeleteMapping("/{medicineId}/skip")
+    @Operation(summary = "영양제 복용 기록 삭제", description = "사용자가 영양제 복용으로 생성된 영양제 복용 기록을 삭제하기 위한 API 입니다.")
+    public ResponseEntity<String> skip(HttpServletRequest request, @PathVariable Long medicineId);
+}

--- a/src/main/java/com/example/holing/bounded_context/medicine/controller/MedicineController.java
+++ b/src/main/java/com/example/holing/bounded_context/medicine/controller/MedicineController.java
@@ -1,6 +1,7 @@
 package com.example.holing.bounded_context.medicine.controller;
 
 import com.example.holing.base.jwt.JwtProvider;
+import com.example.holing.bounded_context.medicine.api.MedicineApi;
 import com.example.holing.bounded_context.medicine.dto.MedicineRequestDto;
 import com.example.holing.bounded_context.medicine.dto.MedicineResponseDto;
 import com.example.holing.bounded_context.medicine.entity.Medicine;
@@ -9,30 +10,25 @@ import com.example.holing.bounded_context.medicine.serivce.MedicineService;
 import com.example.holing.bounded_context.user.entity.User;
 import com.example.holing.bounded_context.user.service.UserService;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/user/medicines")
-public class MedicineController {
+public class MedicineController implements MedicineApi {
 
     private final MedicineService medicineService;
     private final MedicineHistoryService medicineHistoryService;
     private final JwtProvider jwtProvider;
     private final UserService userService;
 
-    @PostMapping("")
-    public ResponseEntity<String> create(HttpServletRequest request, @RequestBody MedicineRequestDto medicineRequestDto) {
+    public ResponseEntity<String> create(HttpServletRequest request, @Valid @RequestBody MedicineRequestDto medicineRequestDto) {
         String accessToken = jwtProvider.getToken(request);
         String userId = jwtProvider.getUserId(accessToken);
 
@@ -42,7 +38,6 @@ public class MedicineController {
         return ResponseEntity.ok().body("약이 성공적으로 생성되었습니다.");
     }
 
-    @GetMapping("")
     public ResponseEntity<?> read(HttpServletRequest request) {
         String accessToken = jwtProvider.getToken(request);
         String userId = jwtProvider.getUserId(accessToken);
@@ -54,7 +49,6 @@ public class MedicineController {
         return ResponseEntity.ok().body(response);
     }
 
-    @PostMapping("/{medicineId}/taken")
     public ResponseEntity<String> taken(HttpServletRequest request, @PathVariable Long medicineId) {
         String accessToken = jwtProvider.getToken(request);
         String userId = jwtProvider.getUserId(accessToken);
@@ -64,7 +58,6 @@ public class MedicineController {
         return ResponseEntity.ok("약 복용 기록이 저장되었습니다.");
     }
 
-    @DeleteMapping("/{medicineId}/skip")
     public ResponseEntity<String> skip(HttpServletRequest request, @PathVariable Long medicineId) {
         String accessToken = jwtProvider.getToken(request);
         String userId = jwtProvider.getUserId(accessToken);

--- a/src/main/java/com/example/holing/bounded_context/medicine/controller/MedicineController.java
+++ b/src/main/java/com/example/holing/bounded_context/medicine/controller/MedicineController.java
@@ -1,0 +1,76 @@
+package com.example.holing.bounded_context.medicine.controller;
+
+import com.example.holing.base.jwt.JwtProvider;
+import com.example.holing.bounded_context.medicine.dto.MedicineRequestDto;
+import com.example.holing.bounded_context.medicine.dto.MedicineResponseDto;
+import com.example.holing.bounded_context.medicine.entity.Medicine;
+import com.example.holing.bounded_context.medicine.serivce.MedicineHistoryService;
+import com.example.holing.bounded_context.medicine.serivce.MedicineService;
+import com.example.holing.bounded_context.user.entity.User;
+import com.example.holing.bounded_context.user.service.UserService;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/user/medicines")
+public class MedicineController {
+
+    private final MedicineService medicineService;
+    private final MedicineHistoryService medicineHistoryService;
+    private final JwtProvider jwtProvider;
+    private final UserService userService;
+
+    @PostMapping("")
+    public ResponseEntity<String> create(HttpServletRequest request, @RequestBody MedicineRequestDto medicineRequestDto) {
+        String accessToken = jwtProvider.getToken(request);
+        String userId = jwtProvider.getUserId(accessToken);
+
+        User user = userService.read(Long.parseLong(userId));
+
+        Medicine response = medicineService.create(user, MedicineRequestDto.toEntity(medicineRequestDto));
+        return ResponseEntity.ok().body("약이 성공적으로 생성되었습니다.");
+    }
+
+    @GetMapping("")
+    public ResponseEntity<?> read(HttpServletRequest request) {
+        String accessToken = jwtProvider.getToken(request);
+        String userId = jwtProvider.getUserId(accessToken);
+
+        User user = userService.read(Long.parseLong(userId));
+
+        List<Medicine> medicines = medicineService.readAll(user);
+        List<MedicineResponseDto> response = medicines.stream().map(MedicineResponseDto::fromEntity).toList();
+        return ResponseEntity.ok().body(response);
+    }
+
+    @PostMapping("/{medicineId}/taken")
+    public ResponseEntity<String> taken(HttpServletRequest request, @PathVariable Long medicineId) {
+        String accessToken = jwtProvider.getToken(request);
+        String userId = jwtProvider.getUserId(accessToken);
+
+        User user = userService.read(Long.parseLong(userId));
+        medicineHistoryService.taken(medicineId);
+        return ResponseEntity.ok("약 복용 기록이 저장되었습니다.");
+    }
+
+    @DeleteMapping("/{medicineId}/skip")
+    public ResponseEntity<String> skip(HttpServletRequest request, @PathVariable Long medicineId) {
+        String accessToken = jwtProvider.getToken(request);
+        String userId = jwtProvider.getUserId(accessToken);
+
+        User user = userService.read(Long.parseLong(userId));
+        medicineHistoryService.skip(medicineId);
+        return ResponseEntity.ok("약 복용 기록이 삭제되었습니다.");
+    }
+}

--- a/src/main/java/com/example/holing/bounded_context/medicine/dto/MedicineRequestDto.java
+++ b/src/main/java/com/example/holing/bounded_context/medicine/dto/MedicineRequestDto.java
@@ -1,11 +1,14 @@
 package com.example.holing.bounded_context.medicine.dto;
 
 import com.example.holing.bounded_context.medicine.entity.Medicine;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalTime;
 
 public record MedicineRequestDto(
+        @Schema(description = "영양제 이름", example = "탁센")
         String name,
+        @Schema(description = "영양제 복용 시간", example = "16:00")
         LocalTime takenAt
 ) {
     public static Medicine toEntity(MedicineRequestDto medicineRequestDto) {

--- a/src/main/java/com/example/holing/bounded_context/medicine/dto/MedicineRequestDto.java
+++ b/src/main/java/com/example/holing/bounded_context/medicine/dto/MedicineRequestDto.java
@@ -1,0 +1,17 @@
+package com.example.holing.bounded_context.medicine.dto;
+
+import com.example.holing.bounded_context.medicine.entity.Medicine;
+
+import java.time.LocalTime;
+
+public record MedicineRequestDto(
+        String name,
+        LocalTime takenAt
+) {
+    public static Medicine toEntity(MedicineRequestDto medicineRequestDto) {
+        return Medicine.builder()
+                .name(medicineRequestDto.name)
+                .takenAt(medicineRequestDto.takenAt)
+                .build();
+    }
+}

--- a/src/main/java/com/example/holing/bounded_context/medicine/dto/MedicineResponseDto.java
+++ b/src/main/java/com/example/holing/bounded_context/medicine/dto/MedicineResponseDto.java
@@ -1,0 +1,27 @@
+package com.example.holing.bounded_context.medicine.dto;
+
+import com.example.holing.bounded_context.medicine.entity.Medicine;
+import com.example.holing.bounded_context.medicine.entity.MedicineHistory;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.Optional;
+
+public record MedicineResponseDto(
+        Long id,
+        String name,
+        LocalTime takenAt,
+        Boolean isTaken
+) {
+    public static MedicineResponseDto fromEntity(Medicine medicine) {
+        Optional<MedicineHistory> recentHistory = medicine.getMedicineHistoryList().stream().findFirst();
+
+        return new MedicineResponseDto(
+                medicine.getId(),
+                medicine.getName(),
+                medicine.getTakenAt(),
+                recentHistory.isPresent() &&
+                        LocalDate.now().equals(recentHistory.get().getCreatedAt().toLocalDate())
+        );
+    }
+}

--- a/src/main/java/com/example/holing/bounded_context/medicine/entity/Medicine.java
+++ b/src/main/java/com/example/holing/bounded_context/medicine/entity/Medicine.java
@@ -1,0 +1,52 @@
+package com.example.holing.bounded_context.medicine.entity;
+
+import com.example.holing.bounded_context.user.entity.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Medicine {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private LocalTime takenAt;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "medicine")
+    private List<MedicineHistory> medicineHistoryList = new ArrayList<>();
+
+    @Builder
+    public Medicine(String name, LocalTime takenAt) {
+        this.name = name;
+        this.takenAt = takenAt;
+    }
+
+    public void setUser(User user) {
+        this.user = user;
+    }
+}

--- a/src/main/java/com/example/holing/bounded_context/medicine/entity/MedicineHistory.java
+++ b/src/main/java/com/example/holing/bounded_context/medicine/entity/MedicineHistory.java
@@ -1,0 +1,37 @@
+package com.example.holing.bounded_context.medicine.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MedicineHistory {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "medicine_id", nullable = false)
+    private Medicine medicine;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    @Builder
+    public MedicineHistory(Medicine medicine, LocalDateTime createdAt) {
+        this.medicine = medicine;
+        this.createdAt = createdAt;
+    }
+}

--- a/src/main/java/com/example/holing/bounded_context/medicine/repository/MedicineHistoryRepository.java
+++ b/src/main/java/com/example/holing/bounded_context/medicine/repository/MedicineHistoryRepository.java
@@ -1,0 +1,17 @@
+package com.example.holing.bounded_context.medicine.repository;
+
+import com.example.holing.bounded_context.medicine.entity.MedicineHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+@Repository
+public interface MedicineHistoryRepository extends JpaRepository<MedicineHistory, Long> {
+    @Query("select mh from MedicineHistory mh " +
+            "where mh.medicine.id = :medicineId " +
+            "AND mh.createdAt BETWEEN :startOfDay AND :endOfDay")
+    Optional<MedicineHistory> findByMedicineAndCreatedAtToday(Long medicineId, LocalDateTime startOfDay, LocalDateTime endOfDay);
+}

--- a/src/main/java/com/example/holing/bounded_context/medicine/repository/MedicineRepository.java
+++ b/src/main/java/com/example/holing/bounded_context/medicine/repository/MedicineRepository.java
@@ -1,0 +1,31 @@
+package com.example.holing.bounded_context.medicine.repository;
+
+import com.example.holing.bounded_context.medicine.entity.Medicine;
+import com.example.holing.bounded_context.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface MedicineRepository extends JpaRepository<Medicine, Long> {
+
+    @Query("select m from Medicine m " +
+            "left join fetch m.medicineHistoryList " +
+            "where m.user = :user")
+    List<Medicine> findAllByUser(User user);
+
+//    @Query(value = "SELECT m.id, m.name, m.taken_at, mh.id " +
+//            "FROM medicine m " +
+//            "LEFT JOIN medicine_history mh ON m.id = mh.medicine_id " +
+//            "AND DATE(mh.created_at) = CURRENT_DATE " +
+//            "WHERE m.user_id = :userId", nativeQuery = true)
+//    List<Object[]> findAllByUserId(Long userId);
+
+
+//    @Query(value = "SELECT m.* FROM medicine m " +
+//            "LEFT JOIN medicine_history mh ON m.id = mh.medicine_id " +
+//            "AND DATE(mh.created_at) = CURRENT_DATE ", nativeQuery = true)
+//    List<Medicine> findAllByUserId(LocalDateTime startOfDay, LocalDateTime endOfDay);
+}

--- a/src/main/java/com/example/holing/bounded_context/medicine/repository/MedicineRepository.java
+++ b/src/main/java/com/example/holing/bounded_context/medicine/repository/MedicineRepository.java
@@ -13,7 +13,7 @@ public interface MedicineRepository extends JpaRepository<Medicine, Long> {
 
     @Query("select m from Medicine m " +
             "left join fetch m.medicineHistoryList " +
-            "where m.user = :user")
+            "where m.user = :user order by m.takenAt asc")
     List<Medicine> findAllByUser(User user);
 
 //    @Query(value = "SELECT m.id, m.name, m.taken_at, mh.id " +

--- a/src/main/java/com/example/holing/bounded_context/medicine/serivce/MedicineHistoryService.java
+++ b/src/main/java/com/example/holing/bounded_context/medicine/serivce/MedicineHistoryService.java
@@ -1,0 +1,44 @@
+package com.example.holing.bounded_context.medicine.serivce;
+
+import com.example.holing.bounded_context.medicine.entity.Medicine;
+import com.example.holing.bounded_context.medicine.entity.MedicineHistory;
+import com.example.holing.bounded_context.medicine.repository.MedicineHistoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class MedicineHistoryService {
+
+    private final MedicineService medicineService;
+    private final MedicineHistoryRepository medicineHistoryRepository;
+
+    public MedicineHistory create(Medicine medicine) {
+        MedicineHistory medicineHistory = MedicineHistory.builder()
+                .medicine(medicine)
+                .createdAt(LocalDateTime.now())
+                .build();
+        return medicineHistoryRepository.save(medicineHistory);
+    }
+
+    public Optional<MedicineHistory> check(Long medicineId) {
+        LocalDateTime startOfDay = LocalDate.now().atStartOfDay();
+        LocalDateTime endOfDay = LocalDate.now().atTime(23, 59, 59);
+        return medicineHistoryRepository.findByMedicineAndCreatedAtToday(medicineId, startOfDay, endOfDay);
+    }
+
+    public void taken(Long medicineId) {
+        if (check(medicineId).isEmpty()) {
+            Medicine medicine = medicineService.readById(medicineId);
+            create(medicine);
+        }
+    }
+
+    public void skip(Long medicineId) {
+        check(medicineId).ifPresent(medicineHistoryRepository::delete);
+    }
+}

--- a/src/main/java/com/example/holing/bounded_context/medicine/serivce/MedicineService.java
+++ b/src/main/java/com/example/holing/bounded_context/medicine/serivce/MedicineService.java
@@ -1,0 +1,32 @@
+package com.example.holing.bounded_context.medicine.serivce;
+
+import com.example.holing.bounded_context.medicine.entity.Medicine;
+import com.example.holing.bounded_context.medicine.repository.MedicineRepository;
+import com.example.holing.bounded_context.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class MedicineService {
+
+    private final MedicineRepository medicineRepository;
+
+    @Transactional
+    public Medicine create(User user, Medicine medicine) {
+        medicine.setUser(user);
+        return medicineRepository.save(medicine);
+    }
+
+    public List<Medicine> readAll(User user) {
+        return medicineRepository.findAllByUser(user);
+    }
+    
+    public Medicine readById(Long medicineId) {
+        return medicineRepository.findById(medicineId)
+                .orElseThrow(() -> new IllegalArgumentException("약이 존재하지 않습니다."));
+    }
+}


### PR DESCRIPTION
### 🔥 작업 동기 및 이슈
- close: #58 
- close: #60 
- close: #59 
- close: #61 

### 🛠️ 변경 사항
- 사용자의 영양제 조회
    - 사용자의 영양제 복용 여부를 오늘 날짜의 복용 기록이 존재하는지 조회한 다음 반환해준다.   
- 사용자의 영양제 복용여부를 체크 및 해제하는 동작 
    - 영양제를 복용한 경우 복용 기록 생성 : 이미 복용기록이 존재하더라도 예외를 발생시키지 않고 복용 여부에 참을 반환한다.
    - 영양제 복용 여부를 취소한 경우 복용 기록 중 오늘 날짜의  레코드를 삭제 : 복용 기록이 존재하지 않더라도 예외를 발생시키지 않고 복용 여부에 거짓을 반환한다.

### ☑️ 테스트 결과
<details>
<summary>영양제 생성</summary>
    <img width="921" alt="image" src="https://github.com/user-attachments/assets/2d1819e0-3c4c-415b-890b-387aaef8dc0e">
</details>

<details>
<summary>영양제 목록 조회</summary>

- 복용시간 오름차순으로 출력
    <img width="921" alt="image" src="https://github.com/user-attachments/assets/f16ce836-522f-420c-a2a5-dfa7261e3b3d">
</details>

<details>
<summary>영양제 복용기록 생성</summary>

- 복용 기록 생성
    <img width="921" alt="image" src="https://github.com/user-attachments/assets/a20e3fa3-84a1-47e6-9a01-f45c5c576486">

- 영양제 목록 조회
    <img width="933" alt="image" src="https://github.com/user-attachments/assets/75162b2b-7e91-4748-bacb-0f120c0ef56f">

</details>

<details>
<summary>영양제 복용기록 삭제</summary>

- 복용 기록 삭제
    <img width="921" alt="image" src="https://github.com/user-attachments/assets/7709fed1-5624-4834-959b-2b9f1bb93810">

- 영양제 목록 조회
    <img width="919" alt="image" src="https://github.com/user-attachments/assets/60bc1a27-56bd-448e-99cd-0dcc5cb0e681">

</details>


### 🌟 참고사항
- Mysql 에서 쿼리를 사용해서 사용자의 영양제를 출력하는데, 오늘 날짜와 일치하는 영양제 기록과 left join 하도록 하여 원하는 테이블이 출력되는 것을 확인했습니다. 
```
SELECT m.id, m.name, m.taken_at, mh.id
            FROM atm.medicine m
            LEFT JOIN atm.medicine_history mh ON m.id = mh.medicine_id
            AND DATE(mh.created_at) = CURRENT_DATE
            WHERE m.user_id = 15;
```
<img width="327" alt="image" src="https://github.com/user-attachments/assets/00339171-33ca-4fff-bcca-4ed29b29b7d7">

즉, 영양제당 오늘날짜의 복용기록을, 없다면 null을 가져오고 싶었습니다. 하지만 오늘날짜의 복용기록만을 가져오는 것이 아닌, 과거의 모든 복용기록이 모두 가져와지거나, 오늘날짜와 일치하는 복용기록이 없는 영양제의 과거 복용기록도 모두 가져오는 문제가 발생했습니다.

- 일단 찾아본 바로는 left join fetch 에서 on 질의어를 지원하지 않는 것 같았습니다. 따라서 native query 를 그대로 사용했습니다. 하지만 DATE함수가 문제인지 CURRENT_DATE 가 문제인지 알아내지 못했습니다.
- native query join, join fetch 의 차이를 모르는 것이 가장 큰 원인이었던 것 같습니다. 이에 시간이 너무 길어질 것 같아 일단 repository 조회시에 모든 복용기록을 읽오고, 최신의 복용기록이 오늘날짜인지 확인하는 로직을 dto에 구현하였습니다. 추후에 문제를 찾아 리팩토링해보겠습니다.
- 추가로 한번의 쿼리가 아닌 두번의 쿼리로 영양제들을 리스트로 찾아오고 복용유무를 리스트로 찾아와 dto에서 연결해주는 방법도 있을 것 같습니다.  