### PR TITLE
사용자 정보 및 리포트 조회 API 구현

### DIFF
--- a/src/main/java/com/example/holing/bounded_context/report/dto/ReportDto.java
+++ b/src/main/java/com/example/holing/bounded_context/report/dto/ReportDto.java
@@ -1,0 +1,24 @@
+package com.example.holing.bounded_context.report.dto;
+
+import com.example.holing.bounded_context.report.entity.Report;
+import com.example.holing.bounded_context.survey.entity.Solution;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record ReportDto(
+        @Schema(description = "점수", example = "5")
+        int score,
+        @Schema(description = "태그 이름", example = "SLEEP_PROBLEM")
+        String tagName,
+        @Schema(description = "제목", example = "무릎의 관절통증에 가장 큰 어려움을 겪어요")
+        String title
+) {
+    public static ReportDto fromEntity(Report report) {
+        String additional = report.getAdditional();
+        Solution solution = report.getSolution();
+        return new ReportDto(
+                report.getScore(),
+                report.getTag().getName(),
+                solution.getIsAdditional() ? additional + solution.getTitle() : solution.getTitle()
+        );
+    }
+}

--- a/src/main/java/com/example/holing/bounded_context/report/service/UserReportService.java
+++ b/src/main/java/com/example/holing/bounded_context/report/service/UserReportService.java
@@ -4,23 +4,32 @@ import com.example.holing.bounded_context.report.entity.Report;
 import com.example.holing.bounded_context.report.entity.UserReport;
 import com.example.holing.bounded_context.report.repository.UserReportRepository;
 import com.example.holing.bounded_context.survey.entity.Tag;
+import com.example.holing.bounded_context.survey.repository.TagRepository;
 import com.example.holing.bounded_context.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class UserReportService {
     private final UserReportRepository userReportRepository;
+    private final TagRepository tagRepository;
 
     public UserReport readWithReportAndSolutionById(Long id) {
         return userReportRepository.findWithReportAndSolutionById(id)
                 .orElseThrow(() -> new IllegalArgumentException("사용자 리포트를 찾을 수 없습니다."));
+    }
+
+    public UserReport readRecentByUser(User user) {
+        return userReportRepository.findFirstByUserOrderByCreatedAtDesc(user)
+                .orElseThrow(() -> new IllegalArgumentException("최신 사용자 리포트를 찾을 수 없습니다."));
     }
 
     public List<UserReport> readAllWithReportByUser(User user) {
@@ -34,7 +43,14 @@ public class UserReportService {
     public List<Tag> getUserRecentReportTag(User user) {
         List<UserReport> userReports = readAllWithReportByUser(user);
         List<Report> reports = userReports.get(userReports.size() - 1).getReports();
-        return reports.stream().map(Report::getTag).toList();
+
+        List<Tag> tags = reports.stream()
+                .sorted(Comparator.comparingInt(Report::getScore).reversed())
+                .map(Report::getTag).collect(Collectors.toList());
+
+        tags.add(tagRepository.findById(7L).get());
+
+        return tags;
     }
 
     @Transactional

--- a/src/main/java/com/example/holing/bounded_context/user/api/UserApi.java
+++ b/src/main/java/com/example/holing/bounded_context/user/api/UserApi.java
@@ -1,6 +1,7 @@
 package com.example.holing.bounded_context.user.api;
 
 import com.example.holing.bounded_context.user.dto.UserInfoResponseDto;
+import com.example.holing.bounded_context.user.dto.UserResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
@@ -17,6 +18,15 @@ import org.springframework.web.bind.annotation.RequestMapping;
 @RequestMapping("/user")
 @Tag(name = "[사용자 관련 API]", description = "사용자관련 API")
 public interface UserApi {
+
+    @GetMapping("/me/reports")
+    @Operation(summary = "본인 정보 및 리포트 조회", description = "사용자가 본인의 정보와 리포트를 조회하기 위한 API 입니다")
+    ResponseEntity<UserResponseDto> readWithReport(HttpServletRequest request);
+
+    @GetMapping("/mate/reports")
+    @Operation(summary = "본인 정보 및 리포트 조회", description = "사용자가 본인의 정보와 리포트를 조회하기 위한 API 입니다")
+    ResponseEntity<UserResponseDto> readMateWithReport(HttpServletRequest request);
+
 
     @GetMapping("/me")
     @Operation(summary = "본인 정보 조회", description = "사용자가 본인의 정보를 조회하기 위한 API 입니다")

--- a/src/main/java/com/example/holing/bounded_context/user/controller/UserController.java
+++ b/src/main/java/com/example/holing/bounded_context/user/controller/UserController.java
@@ -1,8 +1,11 @@
 package com.example.holing.bounded_context.user.controller;
 
 import com.example.holing.base.jwt.JwtProvider;
+import com.example.holing.bounded_context.report.entity.UserReport;
+import com.example.holing.bounded_context.report.service.UserReportService;
 import com.example.holing.bounded_context.user.api.UserApi;
 import com.example.holing.bounded_context.user.dto.UserInfoResponseDto;
+import com.example.holing.bounded_context.user.dto.UserResponseDto;
 import com.example.holing.bounded_context.user.entity.User;
 import com.example.holing.bounded_context.user.service.UserService;
 import jakarta.servlet.http.HttpServletRequest;
@@ -17,12 +20,37 @@ public class UserController implements UserApi {
 
     private final JwtProvider jwtProvider;
     private final UserService userService;
+    private final UserReportService userReportService;
 
 
     public ResponseEntity<String> test() {
         return ResponseEntity.ok().body("테스트 성공");
     }
 
+
+    @Override
+    public ResponseEntity<UserResponseDto> readWithReport(HttpServletRequest request) {
+        String accessToken = jwtProvider.getToken(request);
+        String userId = jwtProvider.getUserId(accessToken);
+
+        User user = userService.read(Long.parseLong(userId));
+        
+        UserReport report = userReportService.readRecentByUser(user);
+        UserResponseDto response = UserResponseDto.of(user, report);
+        return ResponseEntity.ok().body(response);
+    }
+
+    @Override
+    public ResponseEntity<UserResponseDto> readMateWithReport(HttpServletRequest request) {
+        String accessToken = jwtProvider.getToken(request);
+        String userId = jwtProvider.getUserId(accessToken);
+
+        User user = userService.read(Long.parseLong(userId));
+
+        UserReport mateReport = userReportService.readRecentByUser(user.getMate());
+        UserResponseDto response = UserResponseDto.of(user.getMate(), mateReport);
+        return ResponseEntity.ok().body(response);
+    }
 
     public ResponseEntity<UserInfoResponseDto> read(HttpServletRequest request) {
         String accessToken = jwtProvider.getToken(request);

--- a/src/main/java/com/example/holing/bounded_context/user/dto/UserResponseDto.java
+++ b/src/main/java/com/example/holing/bounded_context/user/dto/UserResponseDto.java
@@ -1,0 +1,39 @@
+package com.example.holing.bounded_context.user.dto;
+
+import com.example.holing.bounded_context.report.dto.ReportDto;
+import com.example.holing.bounded_context.report.entity.Report;
+import com.example.holing.bounded_context.report.entity.UserReport;
+import com.example.holing.bounded_context.user.entity.User;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.Comparator;
+import java.util.List;
+
+public record UserResponseDto(
+        String nickname,
+        String mateNickname,
+        long dDay,
+        int totalScore,
+        ReportDto reportTop1,
+        ReportDto reportTop2,
+        Long id,
+        LocalDateTime createdAt
+) {
+    public static UserResponseDto of(User user, UserReport userReport) {
+        List<Report> reports = userReport.getReports().stream()
+                .sorted(Comparator.comparingInt(Report::getScore).reversed()).toList();
+
+        return new UserResponseDto(
+                user.getNickname(),
+                user.getMate().getNickname(),
+                ChronoUnit.DAYS.between(user.getCreatedAt().toLocalDate(), LocalDate.now()),
+                reports.stream().mapToInt(Report::getScore).sum(),
+                ReportDto.fromEntity(reports.get(0)),
+                ReportDto.fromEntity(reports.get(1)),
+                userReport.getId(),
+                userReport.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/example/holing/bounded_context/user/entity/User.java
+++ b/src/main/java/com/example/holing/bounded_context/user/entity/User.java
@@ -1,5 +1,6 @@
 package com.example.holing.bounded_context.user.entity;
 
+import com.example.holing.base.BaseTimeEntity;
 import com.example.holing.bounded_context.auth.dto.OAuthUserInfoDto;
 import com.example.holing.bounded_context.auth.dto.SignInRequestDto;
 import com.example.holing.bounded_context.mission.entity.MissionResult;
@@ -20,7 +21,7 @@ import java.util.List;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class User implements UserDetails {
+public class User extends BaseTimeEntity implements UserDetails {
 
     @OneToMany(mappedBy = "user")
     List<Schedule> schedules = new ArrayList<>();


### PR DESCRIPTION
### 🔥 작업 동기 및 이슈

- close: #70 

### 🛠️ 변경 사항

- 사용자 가입날짜를 관리하기 위한 createdAt 필드 사용으로 bastime entity 상속

### ☑️ 테스트 결과
- GET : {{ip}}/user/me/reports
    <img width="958" alt="image" src="https://github.com/user-attachments/assets/1a4d3e6f-f535-4404-891a-341a1170ea34">

- GET : {{ip}}/user/mate/reports
    <img width="946" alt="image" src="https://github.com/user-attachments/assets/2b09f4e4-c1f8-4941-9da0-07483ebe2509">

### 🌟 참고사항

- 