### PR TITLE
사용자 최신 리포트 조회, 자가 테스트 문항 조회 수정

### DIFF
--- a/src/main/java/com/example/holing/bounded_context/auth/api/AuthApi.java
+++ b/src/main/java/com/example/holing/bounded_context/auth/api/AuthApi.java
@@ -1,6 +1,5 @@
 package com.example.holing.bounded_context.auth.api;
 
-import com.example.holing.bounded_context.auth.dto.OAuthTokenInfoDto;
 import com.example.holing.bounded_context.auth.dto.SignInRequestDto;
 import com.example.holing.bounded_context.user.dto.UserInfoResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
@@ -12,23 +11,21 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.servlet.view.RedirectView;
 
 @RequestMapping("/auth")
 @Tag(name = "[인증 관련 API]", description = "인증, 로그인 및 회원가입, 탈퇴 API")
 public interface AuthApi {
-    @GetMapping("/authorize")
-    @Operation(summary = "소셜 인증", description = "사용자가 소셜 인증을 받기 위한 API 입니다.<br>로그인 후 서비스 필수 항목에 동의가 완료되면 /auth/token 을 호출합니다.")
-    RedirectView authorize();
-
-    @GetMapping("/token")
-    @Operation(summary = "소셜 인증 토큰 반환", description = "사용자가 소셜 인증 토큰을 받기 위한 API 입니다.")
-    ResponseEntity<OAuthTokenInfoDto> token(@RequestParam("code") String code);
+//    @GetMapping("/authorize")
+//    @Operation(summary = "소셜 인증", description = "사용자가 소셜 인증을 받기 위한 API 입니다.<br>로그인 후 서비스 필수 항목에 동의가 완료되면 /auth/token 을 호출합니다.")
+//    RedirectView authorize();
+//
+//    @GetMapping("/token")
+//    @Operation(summary = "소셜 인증 토큰 반환", description = "사용자가 소셜 인증 토큰을 받기 위한 API 입니다.")
+//    ResponseEntity<OAuthTokenInfoDto> token(@RequestParam("code") String code);
 
     @PostMapping("/sign-in")
     @Operation(summary = "로그인 및 회원가입", description = "사용자가 로그인 및 회원가입을 위한 API 입니다.<br>회원가입의 경우 자가테스트의 사용자 정보가 필요합니다.")

--- a/src/main/java/com/example/holing/bounded_context/auth/controller/AuthController.java
+++ b/src/main/java/com/example/holing/bounded_context/auth/controller/AuthController.java
@@ -18,7 +18,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.client.HttpClientErrorException;
-import org.springframework.web.servlet.view.RedirectView;
 
 @RestController
 @RequiredArgsConstructor
@@ -29,50 +28,51 @@ public class AuthController implements AuthApi {
     private final UserService userService;
     private final JwtProvider jwtProvider;
 
-    /**
-     * 인증 코드 받기 요청: 소셜 로그인으로 인가 코드를 받을 수 있는 링크로 리다이렉션 합니다.<br>
-     * 인가 코드 받기 요청의 응답은 HTTP 302 리다이렉트되어, redirect_uri에 GET 요청으로 전달됩니다.<br><br>
-     * <p>
-     * 인가 코드 받기: 로그인 동의 화면을 호출하고, 사용자 동의를 거쳐 인가 코드를 발급합니다.<br>
-     * 사용자가 모든 필수 동의항목에 동의하고 [동의하고 계속하기] 버튼을 누른 경우 : redirect_uri로 인가 코드를 담은 쿼리 스트링 전달됩니다.<br>
-     * 사용자가 동의 화면에서 [취소] 버튼을 눌러 로그인을 취소한 경우 : redirect_uri로 에러 정보를 담은 쿼리 스트링 전달됩니다.<br>
-     * https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api#request-code
-     *
-     * @return uri
-     */
-    @Override
-    public RedirectView authorize() {
-        String uri = oAuthService.getAuthorizeUri();
-        return new RedirectView(uri);
-    }
-
-    /**
-     * 토큰 발급 받기: 소셜 인증이 성공한 경우 이 API로 리다이렉트 되어 토큰을 발급합니다.
-     *
-     * @param code 인가 코드
-     * @return TokenInfoDto 발급된 토큰
-     * @throws HttpClientErrorException 토큰 발급 받기 api 요청 실패 시 발생합니다.
-     */
-    @Override
-    public ResponseEntity<OAuthTokenInfoDto> token(@RequestParam("code") String code) {
-        OAuthTokenInfoDto token = oAuthService.getToken(code);
-        return ResponseEntity.ok().body(token);
-    }
+//    /**
+//     * 인증 코드 받기 요청: 소셜 로그인으로 인가 코드를 받을 수 있는 링크로 리다이렉션 합니다.<br>
+//     * 인가 코드 받기 요청의 응답은 HTTP 302 리다이렉트되어, redirect_uri에 GET 요청으로 전달됩니다.<br><br>
+//     * <p>
+//     * 인가 코드 받기: 로그인 동의 화면을 호출하고, 사용자 동의를 거쳐 인가 코드를 발급합니다.<br>
+//     * 사용자가 모든 필수 동의항목에 동의하고 [동의하고 계속하기] 버튼을 누른 경우 : redirect_uri로 인가 코드를 담은 쿼리 스트링 전달됩니다.<br>
+//     * 사용자가 동의 화면에서 [취소] 버튼을 눌러 로그인을 취소한 경우 : redirect_uri로 에러 정보를 담은 쿼리 스트링 전달됩니다.<br>
+//     * https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api#request-code
+//     *
+//     * @return uri
+//     */
+//    @Override
+//    public RedirectView authorize() {
+//        String uri = oAuthService.getAuthorizeUri();
+//        return new RedirectView(uri);
+//    }
+//
+//    /**
+//     * 토큰 발급 받기: 소셜 인증이 성공한 경우 이 API로 리다이렉트 되어 토큰을 발급합니다.
+//     *
+//     * @param code 인가 코드
+//     * @return TokenInfoDto 발급된 토큰
+//     * @throws HttpClientErrorException 토큰 발급 받기 api 요청 실패 시 발생합니다.
+//     */
+//    @Override
+//    public ResponseEntity<OAuthTokenInfoDto> token(@RequestParam("code") String code) {
+//        OAuthTokenInfoDto token = oAuthService.getToken(code);
+//        return ResponseEntity.ok().body(token);
+//    }
 
     /**
      * 로그인: 인증 서버 ccess token 으로 로그인을 진행합니다.<br>
      * 데이터베이스에 유저가 없는 경우 새 레코드를 생성합니다.<br>
      * 데이터베이스에 유저가 있는 경우 리소스 공급자의 데이터로 레코드를 업데이트합니다.<br>
      *
-     * @param request access token 이 포함된 객체
-     * @return UserInfoDto 유저 정보
+     * @param request 회원가입 객체
+     * @param code    인가 코드
+     * @return
      * @throws HttpClientErrorException 사용자 정보 받기 api 요청 실패 시 발생합니다.
      */
     @Override
     public ResponseEntity<UserInfoResponseDto> signIn(@RequestBody SignInRequestDto request, @RequestParam("code") String code) {
         OAuthTokenInfoDto token = oAuthService.getToken(code);
         OAuthUserInfoDto userInfo = oAuthService.getUserInfo(token.accessToken());
-        
+
         User user = userService.saveOrUpdate(User.of(userInfo, request));
 
         String accessToken = jwtProvider.generatorAccessToken(user.getEmail(), user.getId());
@@ -87,7 +87,6 @@ public class AuthController implements AuthApi {
      * 회원 탈퇴: 회원 아이디로 회원탈퇴를 진행합니다<br>
      * 인증 서버의 아이디로 인증 서버와의 연결을 끊고 데이터베이스에 레코드를 지웁니다.
      *
-     * @param userId 회원 아이디
      * @return
      * @throws HttpClientErrorException 연결 끊기 api 요청 실패 시 발생합니다.
      * @throws IllegalArgumentException 회원이 조회되지 않는 경우 발생합니다.

--- a/src/main/java/com/example/holing/bounded_context/report/dto/UserReportDetailResponseDto.java
+++ b/src/main/java/com/example/holing/bounded_context/report/dto/UserReportDetailResponseDto.java
@@ -17,7 +17,7 @@ public record UserReportDetailResponseDto(
         int month,
         @Schema(description = "주차", example = "1")
         int weekOfMonth,
-        List<ReportDto> reportList
+        List<ReportSummaryDto> reportList
 ) {
     public static UserReportDetailResponseDto fromEntity(UserReport userReport) {
         LocalDateTime createdAt = userReport.getCreatedAt();
@@ -25,13 +25,13 @@ public record UserReportDetailResponseDto(
                 createdAt.getMonthValue(),
                 createdAt.get(WeekFields.of(Locale.getDefault()).weekOfMonth()),
                 userReport.getReports().stream()
-                        .map(ReportDto::fromEntity)
-                        .sorted(Comparator.comparingInt(ReportDto::score).reversed())
+                        .map(ReportSummaryDto::fromEntity)
+                        .sorted(Comparator.comparingInt(ReportSummaryDto::score).reversed())
                         .toList()
         );
     }
 
-    public record ReportDto(
+    public record ReportSummaryDto(
             @Schema(description = "점수", example = "5")
             int score,
             @Schema(description = "태그 이름", example = "SLEEP_PROBLEM")
@@ -40,10 +40,10 @@ public record UserReportDetailResponseDto(
             String title,
             SolutionDto solution
     ) {
-        public static ReportDto fromEntity(Report report) {
+        public static ReportSummaryDto fromEntity(Report report) {
             String additional = report.getAdditional();
             Solution solution = report.getSolution();
-            return new ReportDto(
+            return new ReportSummaryDto(
                     report.getScore(),
                     report.getTag().getName(),
                     solution.getIsAdditional() ? additional + solution.getTitle() : solution.getTitle(),

--- a/src/main/java/com/example/holing/bounded_context/report/dto/UserReportScoreResponseDto.java
+++ b/src/main/java/com/example/holing/bounded_context/report/dto/UserReportScoreResponseDto.java
@@ -15,7 +15,7 @@ public record UserReportScoreResponseDto(
         int month,
         @Schema(description = "주차", example = "1")
         int weekOfMonth,
-        List<ReportDto> reportList
+        List<ReportScoreDto> reportList
 ) {
     public static UserReportScoreResponseDto fromEntity(UserReport userReport) {
         LocalDateTime createdAt = userReport.getCreatedAt();
@@ -23,18 +23,18 @@ public record UserReportScoreResponseDto(
                 createdAt.getMonthValue(),
                 createdAt.get(WeekFields.of(Locale.getDefault()).weekOfMonth()),
                 userReport.getReports().stream()
-                        .map(ReportDto::fromEntity).toList()
+                        .map(ReportScoreDto::fromEntity).toList()
         );
     }
 
-    public record ReportDto(
+    public record ReportScoreDto(
             @Schema(description = "점수", example = "5")
             int score,
             @Schema(description = "태그 이름", example = "SLEEP_PROBLEM")
             String tagName
     ) {
-        public static ReportDto fromEntity(Report report) {
-            return new ReportDto(
+        public static ReportScoreDto fromEntity(Report report) {
+            return new ReportScoreDto(
                     report.getScore(),
                     report.getTag().getName()
             );

--- a/src/main/java/com/example/holing/bounded_context/survey/controller/SurveyController.java
+++ b/src/main/java/com/example/holing/bounded_context/survey/controller/SurveyController.java
@@ -5,6 +5,7 @@ import com.example.holing.bounded_context.survey.dto.SymptomQuestionResponseDto;
 import com.example.holing.bounded_context.survey.entity.SelfQuestion;
 import com.example.holing.bounded_context.survey.entity.SymptomQuestion;
 import com.example.holing.bounded_context.survey.service.SurveyService;
+import com.example.holing.bounded_context.user.entity.Gender;
 import com.example.holing.bounded_context.user.entity.User;
 import com.example.holing.bounded_context.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -14,6 +15,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -41,12 +43,8 @@ public class SurveyController {
 
     @GetMapping("/self-test")
     @Operation(summary = "자가 테스트 문항 조회", description = "사용자가 자가 테스트의 문항을 조회하기 위한 API 입니다")
-    public ResponseEntity<List<SelfQuestion>> readSelfQuestion(HttpServletRequest request) {
-        String accessToken = jwtProvider.getToken(request);
-        String userId = jwtProvider.getUserId(accessToken);
-
-        User user = userService.read(Long.parseLong(userId));
-        List<SelfQuestion> symptomQuestions = surveyService.readSelfByUser(user);
+    public ResponseEntity<List<SelfQuestion>> readSelfQuestion(@RequestParam Gender gender) {
+        List<SelfQuestion> symptomQuestions = surveyService.readSelfByUser(gender);
         return ResponseEntity.ok().body(symptomQuestions);
     }
 }

--- a/src/main/java/com/example/holing/bounded_context/survey/service/SurveyService.java
+++ b/src/main/java/com/example/holing/bounded_context/survey/service/SurveyService.java
@@ -6,7 +6,6 @@ import com.example.holing.bounded_context.survey.entity.Type;
 import com.example.holing.bounded_context.survey.repository.SelfQuestionRepository;
 import com.example.holing.bounded_context.survey.repository.SymptomQuestionRepository;
 import com.example.holing.bounded_context.user.entity.Gender;
-import com.example.holing.bounded_context.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -26,8 +25,8 @@ public class SurveyService {
         return symptomQuestionRepository.findAllByTagNotPeriod();
     }
 
-    public List<SelfQuestion> readSelfByUser(User user) {
+    public List<SelfQuestion> readSelfByUser(Gender gender) {
         return selfQuestionRepository.findAllByTypeNot(
-                user.getGender() == Gender.MALE ? Type.FEMALE : Type.MALE);
+                gender == Gender.MALE ? Type.FEMALE : Type.MALE);
     }
 }

--- a/src/main/java/com/example/holing/bounded_context/user/dto/UserRecentReportResponseDto.java
+++ b/src/main/java/com/example/holing/bounded_context/user/dto/UserRecentReportResponseDto.java
@@ -35,7 +35,7 @@ public record UserRecentReportResponseDto(
                 user.getNickname(),
                 user.getGender(),
                 user.getProfileImgUrl(),
-                user.getMate().getNickname(),
+                user.getMate() != null ? user.getMate().getNickname() : null,
                 ChronoUnit.DAYS.between(user.getCreatedAt().toLocalDate(), LocalDate.now()),
                 UserReportDto.fromEntity(userReport)
         );


### PR DESCRIPTION
### 🔥 작업 동기 및 이슈
- close: #97
- close: #98
- close: #99

### 🛠️ 변경 사항

- 사용자 최신 리포트 조회 시 짝꿍의 닉네임을 출력할 때, 짝꿍이 없는 경우 에러 -> 짝꿍이 없는 경우 null 로 표시
- 자가 테스트 문항 조회는 비로그인 사용자가 사용하므로 성별을 파라미터로 받도록 수정

### ☑️ 테스트 결과

<details>
<summary>본인 및 최신 리포트 조회 GET : {{ip}}/user/me/reports </summary> 
- 성공 : 200 - 본인의 테스트 결과가 없는 경우 + 짝꿍이 존재하는 경우
    <img width="879" alt="image" src="https://github.com/user-attachments/assets/5a32f528-b594-4bb4-a170-1959ae8d994b">

- 성공 : 200 - 본인의 테스트 결과가 있는 경우 + 짝꿍이 존재하는 경우
    <img width="881" alt="image" src="https://github.com/user-attachments/assets/f7e3aaac-2868-4dc4-93e2-e241bcfa0cff">

- 성공 : 200 - 본인의 테스트 결과가 있는 경우 + 짝꿍이 존재하지 않는 경우
    <img width="892" alt="image" src="https://github.com/user-attachments/assets/41c037b3-461c-4177-b623-390d06d70442">
</details>

<details>
<summary>짝꿍 및 최신 리포트 조회 GET : {{ip}}/user/mate/reports </summary> 

- 짝꿍 및 최신 리포트 조회 성공 : 200 - 짝꿍의 테스트 결과가 있는 경우
    <img width="882" alt="image" src="https://github.com/user-attachments/assets/10e552ad-5ae0-4645-b7b6-83c3ba902dba">

- 짝꿍 및 최신 리포트 조회 성공 : 200 - 짝꿍의 테스트 결과가 없는 경우
    <img width="878" alt="image" src="https://github.com/user-attachments/assets/a4dee8ff-a6fc-4cf1-82a4-58e853953cd7">

- 짝꿍이 없는 경우 : 404
    <img width="892" alt="image" src="https://github.com/user-attachments/assets/b6015e2e-3518-47b1-9e63-46a568462325">

</details>


### 🌟 참고사항

- 