### PR TITLE
미션 조회 API 반환값 수정 및 미션 교체 API 로직 업데이트

### DIFF
--- a/src/main/java/com/example/holing/bounded_context/mission/api/MissionApi.java
+++ b/src/main/java/com/example/holing/bounded_context/mission/api/MissionApi.java
@@ -38,14 +38,14 @@ public interface MissionApi {
                                     """),
                     }))
     })
-    ResponseEntity<List<MissionResultResponseDto>> create(HttpServletRequest request);
+    ResponseEntity<?> create(HttpServletRequest request);
 
     @GetMapping("/history")
     @Operation(summary = "미션 조회", description = "특정 날짜의 미션 목록을 조회하는 API입니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "미션 조회 성공")
     })
-    ResponseEntity<List<MissionResultResponseDto>> read(HttpServletRequest request, @RequestParam String date);
+    ResponseEntity<?> read(HttpServletRequest request, @RequestParam String date);
 
     @PatchMapping("/{missionResultId}")
     @Operation(summary = "미션 교체", description = "선택한 미션을 동일한 태그내의 다른 미션으로 교체합니다.")

--- a/src/main/java/com/example/holing/bounded_context/mission/controller/MissionResultController.java
+++ b/src/main/java/com/example/holing/bounded_context/mission/controller/MissionResultController.java
@@ -2,9 +2,12 @@ package com.example.holing.bounded_context.mission.controller;
 
 import com.example.holing.base.jwt.JwtProvider;
 import com.example.holing.bounded_context.mission.api.MissionApi;
+import com.example.holing.bounded_context.mission.dto.MateCheckDto;
 import com.example.holing.bounded_context.mission.dto.MissionCountDto;
 import com.example.holing.bounded_context.mission.dto.MissionResultResponseDto;
 import com.example.holing.bounded_context.mission.service.MissionResultService;
+import com.example.holing.bounded_context.user.entity.User;
+import com.example.holing.bounded_context.user.service.UserService;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -25,15 +28,21 @@ public class MissionResultController implements MissionApi {
 
     private final JwtProvider jwtProvider;
     private final MissionResultService missionResultService;
+    private final UserService userService;
 
     /**
      * 매일 랜덤으로 미션 3개 생성하기 위한 Method
      *
      * @return List<Mission> 생성된 미션 3개
      */
-    public ResponseEntity<List<MissionResultResponseDto>> create(HttpServletRequest request) {
+    public ResponseEntity<?> create(HttpServletRequest request) {
         String accessToken = jwtProvider.getToken(request);
         String userId = jwtProvider.getUserId(accessToken);
+
+        User user = userService.read(Long.parseLong(userId));
+        if (user.getMate() == null) {
+            return ResponseEntity.ok().body(MateCheckDto.fromEntity(false));
+        }
 
         List<MissionResultResponseDto> missionResultList = missionResultService.create(Long.parseLong(userId));
 
@@ -46,9 +55,14 @@ public class MissionResultController implements MissionApi {
      * @param request
      * @return
      */
-    public ResponseEntity<List<MissionResultResponseDto>> read(HttpServletRequest request, @RequestParam String date) {
+    public ResponseEntity<?> read(HttpServletRequest request, @RequestParam String date) {
         String accessToken = jwtProvider.getToken(request);
         String userId = jwtProvider.getUserId(accessToken);
+
+        User user = userService.read(Long.parseLong(userId));
+        if (user.getMate() == null) {
+            return ResponseEntity.ok().body(MateCheckDto.fromEntity(false));
+        }
 
         LocalDate selectedDate = LocalDate.parse(date);
 

--- a/src/main/java/com/example/holing/bounded_context/mission/dto/MateCheckDto.java
+++ b/src/main/java/com/example/holing/bounded_context/mission/dto/MateCheckDto.java
@@ -1,0 +1,11 @@
+package com.example.holing.bounded_context.mission.dto;
+
+public record MateCheckDto(
+        boolean isMateConnected
+) {
+    public static MateCheckDto fromEntity(boolean state) {
+        return new MateCheckDto(
+                state
+        );
+    }
+}

--- a/src/main/java/com/example/holing/bounded_context/mission/dto/MissionInfoDto.java
+++ b/src/main/java/com/example/holing/bounded_context/mission/dto/MissionInfoDto.java
@@ -10,7 +10,7 @@ public record MissionInfoDto(
 
         int reward
 ) {
-    public static MissionInfoDto FromEntity(Mission mission) {
+    public static MissionInfoDto fromEntity(Mission mission) {
         return new MissionInfoDto(
                 mission.getId(),
                 mission.getTitle(),

--- a/src/main/java/com/example/holing/bounded_context/mission/dto/MissionResultResponseDto.java
+++ b/src/main/java/com/example/holing/bounded_context/mission/dto/MissionResultResponseDto.java
@@ -11,7 +11,7 @@ public record MissionResultResponseDto(
         return new MissionResultResponseDto(
                 missionResult.getId(),
                 missionResult.isCompleted(),
-                MissionInfoDto.FromEntity(missionResult.getMission())
+                MissionInfoDto.fromEntity(missionResult.getMission())
         );
     }
 }

--- a/src/main/java/com/example/holing/bounded_context/user/entity/User.java
+++ b/src/main/java/com/example/holing/bounded_context/user/entity/User.java
@@ -5,7 +5,13 @@ import com.example.holing.bounded_context.auth.dto.OAuthUserInfoDto;
 import com.example.holing.bounded_context.auth.dto.SignInRequestDto;
 import com.example.holing.bounded_context.mission.entity.MissionResult;
 import com.example.holing.bounded_context.schedule.entity.Schedule;
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -53,6 +59,9 @@ public class User extends BaseTimeEntity implements UserDetails {
     @Column(nullable = false)
     private Long socialId;
 
+    @Column(nullable = false)
+    private Boolean isChanged;
+
     @OneToOne
     private User mate;
 
@@ -69,6 +78,7 @@ public class User extends BaseTimeEntity implements UserDetails {
         this.isPeriod = (gender == Gender.FEMALE) ? isPeriod : false;
         this.point = 0;
         this.socialId = socialId;
+        this.isChanged = false;
     }
 
     public static User of(OAuthUserInfoDto dto, SignInRequestDto request) {
@@ -136,6 +146,10 @@ public class User extends BaseTimeEntity implements UserDetails {
     @Override
     public boolean isEnabled() {
         return true;
+    }
+
+    public void setIsChanged(boolean state) {
+        this.isChanged = state;
     }
 
 }


### PR DESCRIPTION
### 🔥 작업 동기 및 이슈

- 프론트 요청사항 : 미션 조회 시 짝꿍이 연동되어 있지 않다면 `isMateConnected: False`반환.
- 정상적으로 연동이 된 경우에는 기존과 동일하게 미션 조회됨.

### 🛠️ 변경 사항

- 미션 교체 시 User Entity에 isChanged 필드 추가를 통해서 확인함.
- `미션 완료 처리 후 교체 요청 시 교체가 안되던 문제`와 `미션 교체 후 해당 미션 완료 시 교체 가능했던 문제`를 해결함.

### ☑️ 테스트 결과

- 위 사항 모두 Postman을 통해 확인했으며, 추후 테스트 결과를 작성할 예정.

### 🌟 참고사항

- X