### PR TITLE
미션 교체 관련 이슈사항 처리 & 예외처리 추가 & Swagger 수정

### DIFF
--- a/src/main/java/com/example/holing/bounded_context/mission/api/MissionApi.java
+++ b/src/main/java/com/example/holing/bounded_context/mission/api/MissionApi.java
@@ -51,13 +51,23 @@ public interface MissionApi {
     @Operation(summary = "미션 교체", description = "선택한 미션을 동일한 태그내의 다른 미션으로 교체합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "미션 교체 성공"),
-            @ApiResponse(responseCode = "404", description = "미션 교체 실패",
+            @ApiResponse(responseCode = "400", description = "미션 교체 실패",
                     content = @Content(mediaType = "application/json", examples = {
                             @ExampleObject(value = """
                                                                                 {
-                                                                                    "timeStamp": "2024-07-26T17:30:09.9259602",
-                                                                                    "name": "UPDATED_DENIED",
-                                                                                    "cause": "날짜가 지난 미션은 교체할 수 없습니다."
+                                                                                    "timeStamp": "2024-07-30T22:51:29.3950973",
+                                                                                    "name": "ACCESS_DENIED",
+                                                                                    "cause": "이미 지난 미션입니다."
+                                                                                }
+                                    """),
+                    })),
+            @ApiResponse(responseCode = "400", description = "최신 미션이 존재하지 않음",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                                                                {
+                                                                                    "timeStamp": "2024-07-30T22:51:29.3950973",
+                                                                                    "name": "NOT_EXIST_MISSION",
+                                                                                    "cause": "미션이 존재하지 않습니다."
                                                                                 }
                                     """),
                     })),
@@ -65,9 +75,19 @@ public interface MissionApi {
                     content = @Content(mediaType = "application/json", examples = {
                             @ExampleObject(value = """
                                                                                 {
-                                                                                    "timeStamp": "2024-07-26T17:32:09.4239562",
+                                                                                    "timeStamp": "2024-07-30T22:52:02.7411103",
                                                                                     "name": "ALREADY_UPDATED",
                                                                                     "cause": "이미 미션을 교체하셨습니다."
+                                                                                }
+                                    """),
+                    })),
+            @ApiResponse(responseCode = "400", description = "완료된 미션에 대해 교체 요청",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                                                                {
+                                                                                    "timeStamp": "2024-07-30T22:52:24.7846393",
+                                                                                    "name": "ALREADY_COMPLETED",
+                                                                                    "cause": "이미 완료된 미션입니다."
                                                                                 }
                                     """),
                     }))
@@ -82,9 +102,19 @@ public interface MissionApi {
                     content = @Content(mediaType = "application/json", examples = {
                             @ExampleObject(value = """
                                                                                 {
-                                                                                    "timeStamp": "2024-07-26T17:32:09.4239562",
+                                                                                    "timeStamp": "2024-07-30T22:52:24.7846393",
                                                                                     "name": "ALREADY_COMPLETED",
                                                                                     "cause": "이미 완료된 미션입니다."
+                                                                                }
+                                    """),
+                    })),
+            @ApiResponse(responseCode = "400", description = "과거 미션 완료 요청",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                                                                {
+                                                                                    "timeStamp": "2024-07-30T22:52:51.3695759",
+                                                                                    "name": "ACCESS_DENIED",
+                                                                                    "cause": "이미 지난 미션입니다."
                                                                                 }
                                     """),
                     }))

--- a/src/main/java/com/example/holing/bounded_context/mission/exception/MissionExceptionCode.java
+++ b/src/main/java/com/example/holing/bounded_context/mission/exception/MissionExceptionCode.java
@@ -7,7 +7,8 @@ public enum MissionExceptionCode implements ExceptionCode {
     ALREADY_EXISTS(HttpStatus.CONFLICT, "미션이 최신입니다."),
     ALREADY_UPDATED(HttpStatus.CONFLICT, "이미 미션을 교체하셨습니다."),
     ALREADY_COMPLETED(HttpStatus.CONFLICT, "이미 완료된 미션입니다."),
-    UPDATED_DENIED(HttpStatus.BAD_REQUEST, "날짜가 지난 미션은 교체할 수 없습니다.");
+    ACCESS_DENIED(HttpStatus.BAD_REQUEST, "이미 지난 미션입니다."),
+    NOT_EXIST_MISSION(HttpStatus.BAD_REQUEST, "미션이 존재하지 않습니다.");
 
     HttpStatus httpStatus;
     String cause;

--- a/src/main/java/com/example/holing/bounded_context/mission/service/MissionResultService.java
+++ b/src/main/java/com/example/holing/bounded_context/mission/service/MissionResultService.java
@@ -44,7 +44,7 @@ public class MissionResultService {
         }
 
         user.setIsChanged(false);
-        
+
         List<Mission> missions = missionService.getMissions(userId);
         List<MissionResult> todayMission = new ArrayList<>();
 
@@ -62,7 +62,7 @@ public class MissionResultService {
                 .collect(toList());
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public List<MissionResultResponseDto> read(Long userId, LocalDate date) {
         User user = userService.read(userId);
 


### PR DESCRIPTION
### 🔥 작업 동기 및 이슈

  1. 지난 날짜의 미션에 대해서 `새로고침`을 클릭한 경우 변경이 됨.
  2. 완료한 미션에 대해서 해당 날짜에 `교체`를 하지 않았다면 `완료된 미션도 교체가 가능했음`
  - 추가적으로, 조회 시 사용자의 미션 교체 상태를 `false`로 변환했던 것에 대해서 미션 생성 시 바꾸도록 수정함.

### 🛠️ 변경 사항

- 위 3가지 이슈에 대해서 예외처리 추가 및 코드 수정.
- Swagger에 새롭게 추가된 예외처리를 추가했으며, 기존에 반영되지 않았던 예외처리에 대해서도 반영.

### ☑️ 테스트 결과

- 프론트와 함께 Postman을 통해서 확인

### 🌟 참고사항

- X