### PR TITLE
Report, User 예외 및 명세 추가

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -61,4 +61,4 @@ jobs:
             docker rm holing-was-container
             docker image prune -af
             docker pull ${{ secrets.DOCKERHUB_USERNAME }}/holing-was
-            docker run -d -p 8080:8080 --name holing-was-container ${{ secrets.DOCKERHUB_USERNAME }}/holing-was
+            docker run -d -p 8080:8080 --name holing-was-container -e TZ=Asia/Seoul ${{ secrets.DOCKERHUB_USERNAME }}/holing-was

--- a/src/main/java/com/example/holing/bounded_context/report/api/ReportApi.java
+++ b/src/main/java/com/example/holing/bounded_context/report/api/ReportApi.java
@@ -5,6 +5,10 @@ import com.example.holing.bounded_context.report.dto.UserReportDetailResponseDto
 import com.example.holing.bounded_context.report.dto.UserReportScoreResponseDto;
 import com.example.holing.bounded_context.report.dto.UserReportSummaryResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
@@ -48,7 +52,30 @@ public interface ReportApi {
     public ResponseEntity<List<UserReportSummaryResponseDto>> mateSummary(HttpServletRequest request);
 
     @GetMapping("/reports/{reportId}")
-    @Operation(summary = "리포트 상세 조회", description = "사용자가 리포트를 상세 조회하기 위한 API 입니다")
+    @Operation(summary = "증상 테스트 결과 상세 조회", description = "사용자가 증상 테스트 결과를 상세 조회하기 위한 API 입니다")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "증상 테스트 결과 상세 조회 성공"),
+            @ApiResponse(responseCode = "404", description = "증상 테스트 기록이 존재하지 않는 경우",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                                                                {
+                                                                                    "timestamp": "2024-07-19T17:56:39.188+00:00",
+                                                                                    "name": "TEST_HISTORY_NOT_FOUND_BY_ID",
+                                                                                    "cause": "해당 증상 테스트 기록이 존재하지 않습니다."
+                                                                                }
+                                    """),
+                    })),
+            @ApiResponse(responseCode = "403", description = "증상 테스트 기록에 접근할 수 없는 경우",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                                                                {
+                                                                                    "timestamp": "2024-07-19T17:56:39.188+00:00",
+                                                                                    "name": "ACCESS_DENIED_TO_TEST_HISTORY",
+                                                                                    "cause": "해당 증상 테스트 기록에 접근 권한이 없습니다."
+                                                                                }
+                                    """),
+                    }))
+    })
     public ResponseEntity<UserReportDetailResponseDto> read(HttpServletRequest request, @PathVariable Long reportId);
 
     @PostMapping("/reports")

--- a/src/main/java/com/example/holing/bounded_context/report/api/ReportApi.java
+++ b/src/main/java/com/example/holing/bounded_context/report/api/ReportApi.java
@@ -29,6 +29,7 @@ public interface ReportApi {
             각 테스트 기록의 모든 점수들이 반환됩니다.
             기록이 없는 경우 빈 객체가 반환됩니다.
             """)
+    @ApiResponse(responseCode = "200", description = "본인 증상 테스트 기록 점수 조회 성공")
     ResponseEntity<List<UserReportScoreResponseDto>> score(HttpServletRequest request);
 
     @GetMapping("/user/mate/reports/score")
@@ -38,7 +39,7 @@ public interface ReportApi {
             기록이 없는 경우 빈 객체가 반환됩니다.
             """)
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "증상 테스트 기록 점수 조회 성공"),
+            @ApiResponse(responseCode = "200", description = "짝꿍 증상 테스트 기록 점수 조회 성공"),
             @ApiResponse(responseCode = "404", description = "짝꿍이 존재하지 않는 경우",
                     content = @Content(mediaType = "application/json", examples = {
                             @ExampleObject(value = """
@@ -58,6 +59,7 @@ public interface ReportApi {
             각 테스트 기록에서 가장 점수가 높은 솔루션의 제목이 반환됩니다.
             기록이 없는 경우 빈 객체가 반환됩니다.
             """)
+    @ApiResponse(responseCode = "200", description = "본인 증상 테스트 기록 요약 조회 성공")
     ResponseEntity<List<UserReportSummaryResponseDto>> summary(HttpServletRequest request);
 
     @GetMapping("/user/mate/reports/summary")
@@ -67,7 +69,7 @@ public interface ReportApi {
             기록이 없는 경우 빈 객체가 반환됩니다.
             """)
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "증상 테스트 기록 요약 조회 성공"),
+            @ApiResponse(responseCode = "200", description = "짝꿍 증상 테스트 기록 요약 조회 성공"),
             @ApiResponse(responseCode = "404", description = "짝꿍이 존재하지 않는 경우",
                     content = @Content(mediaType = "application/json", examples = {
                             @ExampleObject(value = """

--- a/src/main/java/com/example/holing/bounded_context/report/api/ReportApi.java
+++ b/src/main/java/com/example/holing/bounded_context/report/api/ReportApi.java
@@ -24,37 +24,69 @@ import java.util.List;
 @Tag(name = "[리포트 관련 API]", description = "리포트 조회 및 생성 API")
 public interface ReportApi {
     @GetMapping("/user/me/reports/score")
-    @Operation(summary = "리포트 점수 조회", description = """
-            사용자가 본인의 리포트 점수들을 조회하기 위한 API 입니다
-            리포트의 태그와 점수 목록을 반환합니다.
+    @Operation(summary = "본인의 증상 테스트 기록 점수 조회", description = """
+            사용자가 본인의 모든 증상 테스트 기록의 점수를 조회하기 위한 API 입니다
+            각 테스트 기록의 모든 점수들이 반환됩니다.
+            기록이 없는 경우 빈 객체가 반환됩니다.
             """)
     ResponseEntity<List<UserReportScoreResponseDto>> score(HttpServletRequest request);
 
     @GetMapping("/user/mate/reports/score")
-    @Operation(summary = "짝꿍 리포트 점수 조회", description = """
-            사용자가 짝꿍의 리포트 점수들을 조회하기 위한 API 입니다
-            리포트의 태그와 점수 목록을 반환합니다.
+    @Operation(summary = "짝꿍의 증상 테스트 기록 점수 조회", description = """
+            사용자가 짝꿍의 모든 증상 테스트 기록의 점수를 조회하기 위한 API 입니다
+            각 테스트 기록의 모든 점수들이 반환됩니다.
+            기록이 없는 경우 빈 객체가 반환됩니다.
             """)
-    public ResponseEntity<List<UserReportScoreResponseDto>> mateScore(HttpServletRequest request);
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "증상 테스트 기록 점수 조회 성공"),
+            @ApiResponse(responseCode = "404", description = "짝꿍이 존재하지 않는 경우",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                                                                {
+                                                                                    "timestamp": "2024-07-19T17:56:39.188+00:00",
+                                                                                    "name": "MATE_NOT_FOUND",
+                                                                                    "cause": "사용자의 짝꿍을 찾을 수 없습니다."
+                                                                                }
+                                    """),
+                    }))
+    })
+    ResponseEntity<List<UserReportScoreResponseDto>> mateScore(HttpServletRequest request);
 
     @GetMapping("/user/me/reports/summary")
-    @Operation(summary = "본인 리포트 요약 조회", description = """
-            사용자가 본인의 리포트 요약들을 조회하기 위한 API 입니다
-            테스트 결과 점수가 가장 높은 증상의 솔루션 제목을 반환합니다.
+    @Operation(summary = "본인의 증상 테스트 기록 요약 조회", description = """
+            사용자가 본인의 모든 증상 테스트 기록의 요약을 조회하기 위한 API 입니다
+            각 테스트 기록에서 가장 점수가 높은 솔루션의 제목이 반환됩니다.
+            기록이 없는 경우 빈 객체가 반환됩니다.
             """)
-    public ResponseEntity<List<UserReportSummaryResponseDto>> summary(HttpServletRequest request);
+    ResponseEntity<List<UserReportSummaryResponseDto>> summary(HttpServletRequest request);
 
     @GetMapping("/user/mate/reports/summary")
-    @Operation(summary = "짝꿍 리포트 요약 조회", description = """
-            사용자가 짝꿍의 리포트 요약들을 조회하기 위한 API 입니다
-            테스트 결과 점수가 가장 높은 증상의 솔루션 제목을 반환합니다.
+    @Operation(summary = "짝꿍의 증상 테스트 기록 요약 조회", description = """
+            사용자가 짝꿍의 모든 증상 테스트 기록의 요약을 조회하기 위한 API 입니다
+            각 테스트 기록에서 가장 점수가 높은 솔루션의 제목이 반환됩니다.
+            기록이 없는 경우 빈 객체가 반환됩니다.
             """)
-    public ResponseEntity<List<UserReportSummaryResponseDto>> mateSummary(HttpServletRequest request);
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "증상 테스트 기록 요약 조회 성공"),
+            @ApiResponse(responseCode = "404", description = "짝꿍이 존재하지 않는 경우",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                                                                {
+                                                                                    "timestamp": "2024-07-19T17:56:39.188+00:00",
+                                                                                    "name": "MATE_NOT_FOUND",
+                                                                                    "cause": "사용자의 짝꿍을 찾을 수 없습니다."
+                                                                                }
+                                    """),
+                    }))
+    })
+    ResponseEntity<List<UserReportSummaryResponseDto>> mateSummary(HttpServletRequest request);
 
     @GetMapping("/reports/{reportId}")
-    @Operation(summary = "증상 테스트 결과 상세 조회", description = "사용자가 증상 테스트 결과를 상세 조회하기 위한 API 입니다")
+    @Operation(summary = "증상 테스트 기록 상세 조회", description = """
+            사용자가 증상 테스트 기록을 상세 조회하기 위한 API 입니다
+            """)
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "증상 테스트 결과 상세 조회 성공"),
+            @ApiResponse(responseCode = "200", description = "증상 테스트 기록 상세 조회 성공"),
             @ApiResponse(responseCode = "404", description = "증상 테스트 기록이 존재하지 않는 경우",
                     content = @Content(mediaType = "application/json", examples = {
                             @ExampleObject(value = """
@@ -76,12 +108,25 @@ public interface ReportApi {
                                     """),
                     }))
     })
-    public ResponseEntity<UserReportDetailResponseDto> read(HttpServletRequest request, @PathVariable Long reportId);
+    ResponseEntity<UserReportDetailResponseDto> read(HttpServletRequest request, @PathVariable Long reportId);
 
     @PostMapping("/reports")
     @Operation(summary = "리포트 생성", description = """
-            사용자의 증상 테스트 결과로 리포트를 생성하기 위한 API 입니다.
-            점수와 사용자 입력 항목을 받습니다. 사용자 입력 항목이 없는 경우 빈 문자열을 입력합니다. 
+            사용자의 증상 테스트 점수로 증상 테스트 기록과 결과를 생성하기 위한 API 입니다.
+            점수와 사용자 입력 항목을 받습니다. 사용자 입력 항목이 없는 경우 빈 문자열을 입력합니다.
             """)
-    public ResponseEntity<String> create(HttpServletRequest request, @RequestBody @Valid @Size(min = 6, max = 6) List<ReportRequestDto> reportRequestDtos);
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "리포트 생성 성공"),
+            @ApiResponse(responseCode = "400", description = "리포트 생성 조건을 만족하지 못한 경우",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                                                                {
+                                                                                    "timestamp": "2024-07-19T17:56:39.188+00:00",
+                                                                                    "name": "USER_REPORT_PERIOD_NOT_MET",
+                                                                                    "cause": "마지막 증상 테스트 이후 7일이 경과해야 합니다."
+                                                                                }
+                                    """),
+                    })),
+    })
+    ResponseEntity<String> create(HttpServletRequest request, @RequestBody @Valid @Size(min = 6, max = 6) List<ReportRequestDto> reportRequestDtos);
 }

--- a/src/main/java/com/example/holing/bounded_context/report/controller/ReportController.java
+++ b/src/main/java/com/example/holing/bounded_context/report/controller/ReportController.java
@@ -86,7 +86,7 @@ public class ReportController implements ReportApi {
 
         User user = userService.read(Long.parseLong(userId));
 
-        UserReport userReport = userReportService.readWithReportAndSolutionById(reportId);
+        UserReport userReport = userReportService.read(user, reportId);
         UserReportDetailResponseDto response = UserReportDetailResponseDto.fromEntity(userReport);
         return ResponseEntity.ok().body(response);
     }

--- a/src/main/java/com/example/holing/bounded_context/report/controller/ReportController.java
+++ b/src/main/java/com/example/holing/bounded_context/report/controller/ReportController.java
@@ -1,5 +1,6 @@
 package com.example.holing.bounded_context.report.controller;
 
+import com.example.holing.base.exception.GlobalException;
 import com.example.holing.base.jwt.JwtProvider;
 import com.example.holing.bounded_context.report.api.ReportApi;
 import com.example.holing.bounded_context.report.dto.ReportRequestDto;
@@ -11,6 +12,7 @@ import com.example.holing.bounded_context.report.entity.UserReport;
 import com.example.holing.bounded_context.report.service.ReportService;
 import com.example.holing.bounded_context.report.service.UserReportService;
 import com.example.holing.bounded_context.user.entity.User;
+import com.example.holing.bounded_context.user.exception.UserExceptionCode;
 import com.example.holing.bounded_context.user.service.UserService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
@@ -38,9 +40,7 @@ public class ReportController implements ReportApi {
         String accessToken = jwtProvider.getToken(request);
         String userId = jwtProvider.getUserId(accessToken);
 
-        User user = userService.read(Long.parseLong(userId));
-
-        List<UserReport> reports = userReportService.readAllWithReportByUser(user);
+        List<UserReport> reports = userReportService.readScore(Long.parseLong(userId));
         List<UserReportScoreResponseDto> response = reports.stream().map(UserReportScoreResponseDto::fromEntity).toList();
         return ResponseEntity.ok().body(response);
     }
@@ -50,9 +50,9 @@ public class ReportController implements ReportApi {
         String userId = jwtProvider.getUserId(accessToken);
 
         User user = userService.read(Long.parseLong(userId));
-        User mate = userService.read(user.getMate().getId());
+        if (user.getMate() == null) throw new GlobalException(UserExceptionCode.MATE_NOT_FOUND);
 
-        List<UserReport> reports = userReportService.readAllWithReportByUser(mate);
+        List<UserReport> reports = userReportService.readScore(user.getMate().getId());
         List<UserReportScoreResponseDto> response = reports.stream().map(UserReportScoreResponseDto::fromEntity).toList();
         return ResponseEntity.ok().body(response);
     }
@@ -61,9 +61,7 @@ public class ReportController implements ReportApi {
         String accessToken = jwtProvider.getToken(request);
         String userId = jwtProvider.getUserId(accessToken);
 
-        User user = userService.read(Long.parseLong(userId));
-
-        List<UserReportSummaryResponseDto> response = userReportService.readAllByUser(user).stream()
+        List<UserReportSummaryResponseDto> response = userReportService.readSummary(Long.parseLong(userId)).stream()
                 .map(UserReportSummaryResponseDto::fromEntity).toList();
         return ResponseEntity.ok().body(response);
     }
@@ -73,9 +71,9 @@ public class ReportController implements ReportApi {
         String userId = jwtProvider.getUserId(accessToken);
 
         User user = userService.read(Long.parseLong(userId));
-        User mate = userService.read(user.getMate().getId());
+        if (user.getMate() == null) throw new GlobalException(UserExceptionCode.MATE_NOT_FOUND);
 
-        List<UserReportSummaryResponseDto> response = userReportService.readAllByUser(mate).stream()
+        List<UserReportSummaryResponseDto> response = userReportService.readSummary(user.getMate().getId()).stream()
                 .map(UserReportSummaryResponseDto::fromEntity).toList();
         return ResponseEntity.ok().body(response);
     }
@@ -86,7 +84,7 @@ public class ReportController implements ReportApi {
 
         User user = userService.read(Long.parseLong(userId));
 
-        UserReport userReport = userReportService.read(user, reportId);
+        UserReport userReport = userReportService.readDetail(user, reportId);
         UserReportDetailResponseDto response = UserReportDetailResponseDto.fromEntity(userReport);
         return ResponseEntity.ok().body(response);
     }

--- a/src/main/java/com/example/holing/bounded_context/report/dto/UserReportSummaryResponseDto.java
+++ b/src/main/java/com/example/holing/bounded_context/report/dto/UserReportSummaryResponseDto.java
@@ -12,7 +12,7 @@ import java.util.Locale;
 @Schema(description = "사용자 리포트 요약 응답 DTO")
 public record UserReportSummaryResponseDto(
         @Schema(description = "사용자 리포트 id", example = "1")
-        Long id,
+        Long reportId,
         @Schema(description = "월", example = "7")
         int month,
         @Schema(description = "주차", example = "1")

--- a/src/main/java/com/example/holing/bounded_context/report/exception/ReportExceptionCode.java
+++ b/src/main/java/com/example/holing/bounded_context/report/exception/ReportExceptionCode.java
@@ -1,0 +1,35 @@
+package com.example.holing.bounded_context.report.exception;
+
+import com.example.holing.base.exception.ExceptionCode;
+import org.springframework.http.HttpStatus;
+
+public enum ReportExceptionCode implements ExceptionCode {
+    TEST_HISTORY_NOT_FOUND_BY_ID(HttpStatus.NOT_FOUND, "해당 증상 테스트 기록이 존재하지 않습니다."),
+    ACCESS_DENIED_TO_TEST_HISTORY(HttpStatus.FORBIDDEN, "해당 증상 테스트 기록에 접근 권한이 없습니다."),
+    TEST_HISTORY_NOT_FOUNT_BY_USER(HttpStatus.NOT_FOUND, "해당 유저의 증상 테스트 기록이 존재하지 않습니다."),
+    USER_REPORT_PERIOD_NOT_MET(HttpStatus.BAD_REQUEST, "마지막 증상 테스트 이후 7일이 경과해야 합니다.");
+
+
+    HttpStatus httpStatus;
+    String cause;
+
+    ReportExceptionCode(HttpStatus httpStatus, String cause) {
+        this.httpStatus = httpStatus;
+        this.cause = cause;
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String getCause() {
+        return cause;
+    }
+
+    @Override
+    public String getName() {
+        return name();
+    }
+}

--- a/src/main/java/com/example/holing/bounded_context/report/exception/ReportExceptionCode.java
+++ b/src/main/java/com/example/holing/bounded_context/report/exception/ReportExceptionCode.java
@@ -6,9 +6,7 @@ import org.springframework.http.HttpStatus;
 public enum ReportExceptionCode implements ExceptionCode {
     TEST_HISTORY_NOT_FOUND_BY_ID(HttpStatus.NOT_FOUND, "해당 증상 테스트 기록이 존재하지 않습니다."),
     ACCESS_DENIED_TO_TEST_HISTORY(HttpStatus.FORBIDDEN, "해당 증상 테스트 기록에 접근 권한이 없습니다."),
-    TEST_HISTORY_NOT_FOUNT_BY_USER(HttpStatus.NOT_FOUND, "해당 유저의 증상 테스트 기록이 존재하지 않습니다."),
     USER_REPORT_PERIOD_NOT_MET(HttpStatus.BAD_REQUEST, "마지막 증상 테스트 이후 7일이 경과해야 합니다.");
-
 
     HttpStatus httpStatus;
     String cause;

--- a/src/main/java/com/example/holing/bounded_context/report/repository/UserReportRepository.java
+++ b/src/main/java/com/example/holing/bounded_context/report/repository/UserReportRepository.java
@@ -31,9 +31,9 @@ public interface UserReportRepository extends JpaRepository<UserReport, Long> {
     @Query("select ur from UserReport ur " +
             "join fetch ur.reports r " +
             "join fetch r.solution " +
-            "where ur.user = :user " +
+            "where ur.user.id = :userId " +
             "order by ur.createdAt desc")
-    List<UserReport> findAllWithReportAndSolutionByUser(User user);
+    List<UserReport> findAllWithReportAndSolutionByUser(Long userId);
 
     /**
      * 특정 리포트를 조회하기 위한 쿼리<br>
@@ -57,8 +57,8 @@ public interface UserReportRepository extends JpaRepository<UserReport, Long> {
      */
     @Query("select ur from UserReport ur " +
             "join fetch ur.reports r " +
-            "where ur.user = :user " +
+            "where ur.user.id = :userId " +
             "order by ur.createdAt asc"
     )
-    List<UserReport> findAllWithReportByUser(User user);
+    List<UserReport> findAllWithReportByUser(Long userId);
 }

--- a/src/main/java/com/example/holing/bounded_context/report/service/UserReportService.java
+++ b/src/main/java/com/example/holing/bounded_context/report/service/UserReportService.java
@@ -1,7 +1,9 @@
 package com.example.holing.bounded_context.report.service;
 
+import com.example.holing.base.exception.GlobalException;
 import com.example.holing.bounded_context.report.entity.Report;
 import com.example.holing.bounded_context.report.entity.UserReport;
+import com.example.holing.bounded_context.report.exception.ReportExceptionCode;
 import com.example.holing.bounded_context.report.repository.UserReportRepository;
 import com.example.holing.bounded_context.survey.entity.Tag;
 import com.example.holing.bounded_context.survey.repository.TagRepository;
@@ -24,12 +26,12 @@ public class UserReportService {
 
     public UserReport readWithReportAndSolutionById(Long id) {
         return userReportRepository.findWithReportAndSolutionById(id)
-                .orElseThrow(() -> new IllegalArgumentException("사용자 리포트를 찾을 수 없습니다."));
+                .orElseThrow(() -> new GlobalException(ReportExceptionCode.TEST_HISTORY_NOT_FOUND_BY_ID));
     }
 
     public UserReport readRecentByUser(User user) {
         return userReportRepository.findFirstByUserOrderByCreatedAtDesc(user)
-                .orElseThrow(() -> new IllegalArgumentException("최신 사용자 리포트를 찾을 수 없습니다."));
+                .orElseThrow(() -> new GlobalException(ReportExceptionCode.TEST_HISTORY_NOT_FOUNT_BY_USER));
     }
 
     public List<UserReport> readAllWithReportByUser(User user) {
@@ -38,6 +40,12 @@ public class UserReportService {
 
     public List<UserReport> readAllByUser(User user) {
         return userReportRepository.findAllWithReportAndSolutionByUser(user);
+    }
+
+    public UserReport read(User user, Long id) {
+        UserReport userReport = readWithReportAndSolutionById(id);
+        if (user != userReport.getUser()) throw new GlobalException(ReportExceptionCode.ACCESS_DENIED_TO_TEST_HISTORY);
+        return userReport;
     }
 
     public List<Tag> getUserRecentReportTag(User user) {

--- a/src/main/java/com/example/holing/bounded_context/survey/controller/SurveyController.java
+++ b/src/main/java/com/example/holing/bounded_context/survey/controller/SurveyController.java
@@ -12,6 +12,9 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -43,8 +46,9 @@ public class SurveyController {
 
     @GetMapping("/self-test")
     @Operation(summary = "자가 테스트 문항 조회", description = "사용자가 자가 테스트의 문항을 조회하기 위한 API 입니다")
-    public ResponseEntity<List<SelfQuestion>> readSelfQuestion(@RequestParam Gender gender) {
-        List<SelfQuestion> symptomQuestions = surveyService.readSelfByUser(gender);
-        return ResponseEntity.ok().body(symptomQuestions);
+    public ResponseEntity<Page<SelfQuestion>> readSelfQuestion(@RequestParam Gender gender,
+                                                               @PageableDefault(page = 0, size = 1) Pageable pageable) {
+        Page<SelfQuestion> response = surveyService.readSelfByUser(gender, pageable);
+        return ResponseEntity.ok().body(response);
     }
 }

--- a/src/main/java/com/example/holing/bounded_context/survey/repository/SelfQuestionRepository.java
+++ b/src/main/java/com/example/holing/bounded_context/survey/repository/SelfQuestionRepository.java
@@ -2,10 +2,10 @@ package com.example.holing.bounded_context.survey.repository;
 
 import com.example.holing.bounded_context.survey.entity.SelfQuestion;
 import com.example.holing.bounded_context.survey.entity.Type;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
-
-import java.util.List;
 
 @Repository
 public interface SelfQuestionRepository extends JpaRepository<SelfQuestion, Long> {
@@ -15,5 +15,5 @@ public interface SelfQuestionRepository extends JpaRepository<SelfQuestion, Long
      *
      * @return
      */
-    List<SelfQuestion> findAllByTypeNot(Type type);
+    Page<SelfQuestion> findAllByTypeNot(Type type, Pageable pageable);
 }

--- a/src/main/java/com/example/holing/bounded_context/survey/service/SurveyService.java
+++ b/src/main/java/com/example/holing/bounded_context/survey/service/SurveyService.java
@@ -7,6 +7,8 @@ import com.example.holing.bounded_context.survey.repository.SelfQuestionReposito
 import com.example.holing.bounded_context.survey.repository.SymptomQuestionRepository;
 import com.example.holing.bounded_context.user.entity.Gender;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -25,8 +27,9 @@ public class SurveyService {
         return symptomQuestionRepository.findAllByTagNotPeriod();
     }
 
-    public List<SelfQuestion> readSelfByUser(Gender gender) {
+    public Page<SelfQuestion> readSelfByUser(Gender gender, Pageable pageable) {
         return selfQuestionRepository.findAllByTypeNot(
-                gender == Gender.MALE ? Type.FEMALE : Type.MALE);
+                gender == Gender.MALE ? Type.FEMALE : Type.MALE,
+                pageable);
     }
 }

--- a/src/main/java/com/example/holing/bounded_context/user/api/UserApi.java
+++ b/src/main/java/com/example/holing/bounded_context/user/api/UserApi.java
@@ -20,13 +20,14 @@ import org.springframework.web.bind.annotation.RequestMapping;
 public interface UserApi {
 
     @GetMapping("/me/reports")
-    @Operation(summary = "본인 정보 및 리포트 조회", description = "사용자가 본인의 정보와 리포트를 조회하기 위한 API 입니다")
+    @Operation(summary = "본인 정보 및 최신 리포트 조회", description = "사용자가 본인의 정보와 리포트를 조회하기 위한 API 입니다")
+    @ApiResponse(responseCode = "200", description = "본인 정보 및 최신 리포트 조회 성공")
     ResponseEntity<UserRecentReportResponseDto> readWithReport(HttpServletRequest request);
 
     @GetMapping("/mate/reports")
-    @Operation(summary = "짝꿍 정보 및 리포트 조회", description = "사용자가 짝꿍의 정보와 리포트를 조회하기 위한 API 입니다")
+    @Operation(summary = "짝꿍 정보 및 최신 리포트 조회", description = "사용자가 짝꿍의 정보와 리포트를 조회하기 위한 API 입니다")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "증상 테스트 기록 요약 조회 성공"),
+            @ApiResponse(responseCode = "200", description = "짝꿍 정보 및 최신 리포트 조회 성공"),
             @ApiResponse(responseCode = "404", description = "짝꿍이 존재하지 않는 경우",
                     content = @Content(mediaType = "application/json", examples = {
                             @ExampleObject(value = """
@@ -67,9 +68,9 @@ public interface UserApi {
 //    ResponseEntity<UserInfoDto> read(@PathVariable Long userId);
 
     @PatchMapping("/connect/{socialId}")
-    @Operation(summary = "짝꿍 연결", description = "사용자가 대상 사용자와 짝궁으로 연결하기 위한 API 입니다")
+    @Operation(summary = "짝꿍 연결", description = "사용자가 대상 사용자와 짝꿍으로 연결하기 위한 API 입니다")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "짝궁 연결 성공"),
+            @ApiResponse(responseCode = "200", description = "짝꿍 연결 성공"),
             @ApiResponse(responseCode = "404", description = "사용자 또는 대상 사용자를 조회할 수 없는 경우",
                     content = @Content(mediaType = "application/json", examples = {
                             @ExampleObject(name = "USER_NOT_FOUND", value = """

--- a/src/main/java/com/example/holing/bounded_context/user/api/UserApi.java
+++ b/src/main/java/com/example/holing/bounded_context/user/api/UserApi.java
@@ -24,9 +24,21 @@ public interface UserApi {
     ResponseEntity<UserRecentReportResponseDto> readWithReport(HttpServletRequest request);
 
     @GetMapping("/mate/reports")
-    @Operation(summary = "본인 정보 및 리포트 조회", description = "사용자가 본인의 정보와 리포트를 조회하기 위한 API 입니다")
+    @Operation(summary = "짝꿍 정보 및 리포트 조회", description = "사용자가 짝꿍의 정보와 리포트를 조회하기 위한 API 입니다")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "증상 테스트 기록 요약 조회 성공"),
+            @ApiResponse(responseCode = "404", description = "짝꿍이 존재하지 않는 경우",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                                                                {
+                                                                                    "timestamp": "2024-07-19T17:56:39.188+00:00",
+                                                                                    "name": "MATE_NOT_FOUND",
+                                                                                    "cause": "사용자의 짝꿍을 찾을 수 없습니다."
+                                                                                }
+                                    """),
+                    }))
+    })
     ResponseEntity<UserRecentReportResponseDto> readMateWithReport(HttpServletRequest request);
-
 
     @GetMapping("/me")
     @Operation(summary = "본인 정보 조회", description = "사용자가 본인의 정보를 조회하기 위한 API 입니다")
@@ -60,8 +72,7 @@ public interface UserApi {
             @ApiResponse(responseCode = "200", description = "짝궁 연결 성공"),
             @ApiResponse(responseCode = "404", description = "사용자 또는 대상 사용자를 조회할 수 없는 경우",
                     content = @Content(mediaType = "application/json", examples = {
-                            @ExampleObject(name = "USER_NOT_FOUND", description = """
-                                    """, value = """
+                            @ExampleObject(name = "USER_NOT_FOUND", value = """
                                                                                 {
                                                                                     "timestamp": "2024-07-19T17:56:39.188+00:00",
                                                                                     "name": "USER_NOT_FOUND",

--- a/src/main/java/com/example/holing/bounded_context/user/controller/UserController.java
+++ b/src/main/java/com/example/holing/bounded_context/user/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.example.holing.bounded_context.user.controller;
 
+import com.example.holing.base.exception.GlobalException;
 import com.example.holing.base.jwt.JwtProvider;
 import com.example.holing.bounded_context.report.entity.UserReport;
 import com.example.holing.bounded_context.report.service.UserReportService;
@@ -7,12 +8,15 @@ import com.example.holing.bounded_context.user.api.UserApi;
 import com.example.holing.bounded_context.user.dto.UserInfoResponseDto;
 import com.example.holing.bounded_context.user.dto.UserRecentReportResponseDto;
 import com.example.holing.bounded_context.user.entity.User;
+import com.example.holing.bounded_context.user.exception.UserExceptionCode;
 import com.example.holing.bounded_context.user.service.UserService;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Optional;
 
 @RestController
 @RequiredArgsConstructor
@@ -35,7 +39,7 @@ public class UserController implements UserApi {
 
         User user = userService.read(Long.parseLong(userId));
 
-        UserReport report = userReportService.readRecentByUser(user);
+        Optional<UserReport> report = userReportService.readRecentByUser(user);
         UserRecentReportResponseDto response = UserRecentReportResponseDto.of(user, report);
         return ResponseEntity.ok().body(response);
     }
@@ -46,8 +50,9 @@ public class UserController implements UserApi {
         String userId = jwtProvider.getUserId(accessToken);
 
         User user = userService.read(Long.parseLong(userId));
+        if (user.getMate() == null) throw new GlobalException(UserExceptionCode.MATE_NOT_FOUND);
 
-        UserReport mateReport = userReportService.readRecentByUser(user.getMate());
+        Optional<UserReport> mateReport = userReportService.readRecentByUser(user.getMate());
         UserRecentReportResponseDto response = UserRecentReportResponseDto.of(user.getMate(), mateReport);
         return ResponseEntity.ok().body(response);
     }

--- a/src/main/java/com/example/holing/bounded_context/user/dto/UserInfoResponseDto.java
+++ b/src/main/java/com/example/holing/bounded_context/user/dto/UserInfoResponseDto.java
@@ -24,8 +24,8 @@ public record UserInfoResponseDto(
         int point,
         @Schema(description = "소셜 ID", example = "1234567890")
         Long socialId,
-        @Schema(description = "짝꿍 ID", example = "2")
-        Long mateId
+        @Schema(description = "짝꿍 닉네임", example = "mateNickname")
+        String mateNickname
 ) {
     public static UserInfoResponseDto fromEntity(User user) {
         return new UserInfoResponseDto(
@@ -38,7 +38,7 @@ public record UserInfoResponseDto(
                 user.getPoint(),
                 user.getSocialId(),
                 Optional.ofNullable(user.getMate())
-                        .map(User::getId)
+                        .map(User::getNickname)
                         .orElse(null)
         );
     }


### PR DESCRIPTION
### 🔥 작업 동기 및 이슈

- #34
- #35
- #36 
- #70
- #22
- close: #95
- close: #96
- close: #105

### 🛠️ 변경 사항

- 짝꿍 리포트 점수 조회 : 짝꿍이 존재하지 않는 경우 예외 추가
- 짝꿍 리포트 요약 조회 : 짝꿍이 존재하지 않는 경우 예외 추가
- 리포트 상세 조회 : 리포트가 존재하지 않는 경우 / 리포트가 본인 리포트가 아닌 경우 예외 추가
- 본인 및 최신 리포트 조회
    - 리포트가 없는 경우 null
    - 짝꿍이 없는 경우 null 
- 짝꿍 및 최신 리포트 조회 : 짝꿍이 존재하지 않는 경우 예외 추가  
- 본인 정보 조회 : 짝꿍 닉네임 반환 추가
- 자가 테스트 : 페이징 사용으로 하나씩 조회

- docker continaer 시간 설정 

### ☑️ 테스트 결과

- 이슈 목록에서 업데이트 했습니다.

### 🌟 참고사항

- 