### PR TITLE
report 생성 필드 및 로직 수정

### DIFF
--- a/src/main/java/com/example/holing/bounded_context/report/api/ReportApi.java
+++ b/src/main/java/com/example/holing/bounded_context/report/api/ReportApi.java
@@ -11,8 +11,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.Size;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -130,5 +128,5 @@ public interface ReportApi {
                                     """),
                     })),
     })
-    ResponseEntity<String> create(HttpServletRequest request, @RequestBody @Valid @Size(min = 6, max = 6) List<ReportRequestDto> reportRequestDtos);
+    ResponseEntity<String> create(HttpServletRequest request, @RequestBody List<ReportRequestDto> reportRequestDtos);
 }

--- a/src/main/java/com/example/holing/bounded_context/report/controller/ReportController.java
+++ b/src/main/java/com/example/holing/bounded_context/report/controller/ReportController.java
@@ -15,8 +15,6 @@ import com.example.holing.bounded_context.user.entity.User;
 import com.example.holing.bounded_context.user.exception.UserExceptionCode;
 import com.example.holing.bounded_context.user.service.UserService;
 import jakarta.servlet.http.HttpServletRequest;
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.Size;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -89,7 +87,7 @@ public class ReportController implements ReportApi {
         return ResponseEntity.ok().body(response);
     }
 
-    public ResponseEntity<String> create(HttpServletRequest request, @RequestBody @Valid @Size(min = 6, max = 6) List<ReportRequestDto> reportRequestDtos) {
+    public ResponseEntity<String> create(HttpServletRequest request, @RequestBody List<ReportRequestDto> reportRequestDtos) {
         String accessToken = jwtProvider.getToken(request);
         String userId = jwtProvider.getUserId(accessToken);
 

--- a/src/main/java/com/example/holing/bounded_context/report/service/ReportService.java
+++ b/src/main/java/com/example/holing/bounded_context/report/service/ReportService.java
@@ -25,7 +25,7 @@ public class ReportService {
 
     @Transactional
     public List<Report> create(User user, List<ReportRequestDto> dto) {
-        if (!validateReportByPeriod(user, dto)) throw new IllegalArgumentException("알맞은 검사가 아닙니다.");
+//        if (!validateReportByPeriod(user, dto)) throw new IllegalArgumentException("알맞은 검사가 아닙니다.");
         UserReport userReport = userReportService.create(user);
 
         List<Tag> tagList = tagRepository.findAllWithSolution();
@@ -43,18 +43,18 @@ public class ReportService {
                             .filter(solution -> solution.getMinScore() <= reportRequestDto.score())
                             .min((s1, s2) -> s2.getMinScore() - s1.getMinScore())
                             .get())
-                    .additional(reportRequestDto.additional().isEmpty() ? null : reportRequestDto.additional())
+                    .additional(reportRequestDto.additional() == null ? null : reportRequestDto.additional())
                     .build();
 
             return reportRepository.save(report);
         }).toList();
     }
 
-    public Boolean validateReportByPeriod(User user, List<ReportRequestDto> reportRequestDtos) {
-        ReportRequestDto reportRequestDto = reportRequestDtos.get(5);
-        if (user.getIsPeriod()) {
-            return reportRequestDto.score() != 0;
-        }
-        return reportRequestDto.score() == 0;
-    }
+//    public Boolean validateReportByPeriod(User user, List<ReportRequestDto> reportRequestDtos) {
+//        ReportRequestDto reportRequestDto = reportRequestDtos.get(5);
+//        if (user.getIsPeriod()) {
+//            return reportRequestDto.score() != 0;
+//        }
+//        return reportRequestDto.score() == 0;
+//    }
 }


### PR DESCRIPTION
### 🔥 작업 동기 및 이슈

- close: #92

### 🛠️ 변경 사항

- report 생성 필드 수정
- 사용자는 월경 유무로 다른 질문지를 받으므로 반환도 다르게 된다. 따라서 반환된 질문지와 동일한 태그와 점수만을 받는 것이 더 맞는 방식으로 여겨진다. 리포트 생성시에 일단 유효성 검사를 삭제하고 없는 태그의 점수도 생성하는 대신, 리포트 점수를 읽을 때 생성해서 반환하도록 해야 한다. 

### ☑️ 테스트 결과

- <img width="1051" alt="image" src="https://github.com/user-attachments/assets/295228f1-13ee-4278-a8b2-41aa8f5f3ea7">


### 🌟 참고사항

- 