### PR TITLE
Report score, summary API 수정

### DIFF
--- a/src/main/java/com/example/holing/bounded_context/report/dto/UserReportScoreResponseDto.java
+++ b/src/main/java/com/example/holing/bounded_context/report/dto/UserReportScoreResponseDto.java
@@ -8,6 +8,7 @@ import java.time.LocalDateTime;
 import java.time.temporal.WeekFields;
 import java.util.List;
 import java.util.Locale;
+import java.util.stream.Collectors;
 
 @Schema(description = "사용자 리포트 점수 응답 DTO")
 public record UserReportScoreResponseDto(
@@ -19,11 +20,15 @@ public record UserReportScoreResponseDto(
 ) {
     public static UserReportScoreResponseDto fromEntity(UserReport userReport) {
         LocalDateTime createdAt = userReport.getCreatedAt();
+        List<ReportScoreDto> list = userReport.getReports().stream()
+                .map(ReportScoreDto::fromEntity)
+                .collect(Collectors.toList());
+        if (list.size() == 5) list.add(new ReportScoreDto(0, "PERIOD"));
+
         return new UserReportScoreResponseDto(
                 createdAt.getMonthValue(),
                 createdAt.get(WeekFields.of(Locale.getDefault()).weekOfMonth()),
-                userReport.getReports().stream()
-                        .map(ReportScoreDto::fromEntity).toList()
+                list
         );
     }
 

--- a/src/main/java/com/example/holing/bounded_context/report/dto/UserReportScoreResponseDto.java
+++ b/src/main/java/com/example/holing/bounded_context/report/dto/UserReportScoreResponseDto.java
@@ -23,7 +23,7 @@ public record UserReportScoreResponseDto(
         List<ReportScoreDto> list = userReport.getReports().stream()
                 .map(ReportScoreDto::fromEntity)
                 .collect(Collectors.toList());
-        if (list.size() == 5) list.add(new ReportScoreDto(0, "PERIOD"));
+        if (list.size() == 5) list.add(new ReportScoreDto(null, "PERIOD"));
 
         return new UserReportScoreResponseDto(
                 createdAt.getMonthValue(),
@@ -34,7 +34,7 @@ public record UserReportScoreResponseDto(
 
     public record ReportScoreDto(
             @Schema(description = "점수", example = "5")
-            int score,
+            Integer score,
             @Schema(description = "태그 이름", example = "SLEEP_PROBLEM")
             String tagName
     ) {

--- a/src/main/java/com/example/holing/bounded_context/report/repository/UserReportRepository.java
+++ b/src/main/java/com/example/holing/bounded_context/report/repository/UserReportRepository.java
@@ -2,6 +2,7 @@ package com.example.holing.bounded_context.report.repository;
 
 import com.example.holing.bounded_context.report.entity.UserReport;
 import com.example.holing.bounded_context.user.entity.User;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
@@ -25,15 +26,14 @@ public interface UserReportRepository extends JpaRepository<UserReport, Long> {
      * 사용자의 모든 리포트를 최신순으로 조회하기 위한 쿼리<br>
      * 리포트 요약에서 리포트와 솔루션을 조회하기 위한 용도로 사용합니다.
      *
-     * @param user
+     * @param userId
      * @return
      */
     @Query("select ur from UserReport ur " +
             "join fetch ur.reports r " +
             "join fetch r.solution " +
-            "where ur.user.id = :userId " +
-            "order by ur.createdAt desc")
-    List<UserReport> findAllWithReportAndSolutionByUser(Long userId);
+            "where ur.user.id = :userId")
+    List<UserReport> findTop4WithReportAndSolutionByUser(Long userId, Pageable pageable);
 
     /**
      * 특정 리포트를 조회하기 위한 쿼리<br>
@@ -52,7 +52,7 @@ public interface UserReportRepository extends JpaRepository<UserReport, Long> {
      * 사용자의 모든 리포트를 과거순으로 조회하기 위한 쿼리<br>
      * 사용자 리포트 그래프에서 사용자의 리포트, 리포트의 정보를 출력하기 위해 사용합니다.
      *
-     * @param user
+     * @param userId
      * @return
      */
     @Query("select ur from UserReport ur " +

--- a/src/main/java/com/example/holing/bounded_context/report/service/UserReportService.java
+++ b/src/main/java/com/example/holing/bounded_context/report/service/UserReportService.java
@@ -9,6 +9,9 @@ import com.example.holing.bounded_context.survey.entity.Tag;
 import com.example.holing.bounded_context.survey.repository.TagRepository;
 import com.example.holing.bounded_context.user.entity.User;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -33,7 +36,8 @@ public class UserReportService {
     }
 
     public List<UserReport> readSummary(Long userId) {
-        return userReportRepository.findAllWithReportAndSolutionByUser(userId);
+        Pageable pageable = PageRequest.of(0, 4, Sort.by(Sort.Direction.DESC, "createdAt"));
+        return userReportRepository.findTop4WithReportAndSolutionByUser(userId, pageable);
     }
 
     public UserReport readDetail(User user, Long id) {


### PR DESCRIPTION
### 🔥 작업 동기 및 이슈

- close: #93
- close: #94

### 🛠️ 변경 사항

- 사용자 정보에 따라 달라지는 증상 테스트로 인해 저장되지 않는 태그 점수를 표시하기 위해 6번 태그가 없다면 null 로 추가해서 반환
- 최대 4개의 리포트 요약을 반환하기 위해 pageable 을 사용

### ☑️ 테스트 결과

- 상위 3개만 반환된 경우
    <img width="530" alt="image" src="https://github.com/user-attachments/assets/9a5c9652-1342-4b8f-bad0-e69be45f6031">

- 점수가 입력되지 않은 경우 null 을 포함, 입력된 경우 그대로 출력
    <img width="362" alt="image" src="https://github.com/user-attachments/assets/93c42ae0-6e3d-41a3-a0c5-f3ed3f65872d">

### 🌟 참고사항

- 