### PR TITLE
상품 교환 API 추가

### DIFF
--- a/src/main/java/com/example/holing/bounded_context/user/api/UserApi.java
+++ b/src/main/java/com/example/holing/bounded_context/user/api/UserApi.java
@@ -1,5 +1,6 @@
 package com.example.holing.bounded_context.user.api;
 
+import com.example.holing.bounded_context.user.dto.UserExchangeRequestDto;
 import com.example.holing.bounded_context.user.dto.UserInfoResponseDto;
 import com.example.holing.bounded_context.user.dto.UserRecentReportResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
@@ -13,6 +14,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 @RequestMapping("/user")
@@ -131,4 +134,21 @@ public interface UserApi {
                     })),
     })
     ResponseEntity<String> disconnectMate(HttpServletRequest request);
+
+    @PostMapping("/product/exchanges")
+    @Operation(summary = "상품 교환", description = "사용자가 마이페이지에서 상품을 교환하기 위한 API 입니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "상품 교환 성공"),
+            @ApiResponse(responseCode = "400", description = "사용자의 포인트가 상품의 포인트보다 부족한 경우 발생합니다.",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "LACK_OF_POINT", value = """
+                                                                                {
+                                                                                    "timeStamp": "2024-07-31T22:04:33.1247853",
+                                                                                    "name": "LACK_OF_POINT",
+                                                                                    "cause": "포인트가 부족합니다."
+                                                                                }
+                                    """)
+                    })),
+    })
+    ResponseEntity<UserInfoResponseDto> exchange(HttpServletRequest request, @RequestBody UserExchangeRequestDto userExchangeRequestDto);
 }

--- a/src/main/java/com/example/holing/bounded_context/user/controller/UserController.java
+++ b/src/main/java/com/example/holing/bounded_context/user/controller/UserController.java
@@ -5,6 +5,7 @@ import com.example.holing.base.jwt.JwtProvider;
 import com.example.holing.bounded_context.report.entity.UserReport;
 import com.example.holing.bounded_context.report.service.UserReportService;
 import com.example.holing.bounded_context.user.api.UserApi;
+import com.example.holing.bounded_context.user.dto.UserExchangeRequestDto;
 import com.example.holing.bounded_context.user.dto.UserInfoResponseDto;
 import com.example.holing.bounded_context.user.dto.UserRecentReportResponseDto;
 import com.example.holing.bounded_context.user.entity.User;
@@ -14,6 +15,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.Optional;
@@ -98,6 +100,15 @@ public class UserController implements UserApi {
         userService.disconnectMate(Long.parseLong(acceptUserId));
 
         return ResponseEntity.ok().body("짝꿍 해제에 성공했습니다.");
+    }
+
+    public ResponseEntity<UserInfoResponseDto> exchange(HttpServletRequest request, @RequestBody UserExchangeRequestDto userExchangeRequestDto) {
+        String accessToken = jwtProvider.getToken(request);
+        String userId = jwtProvider.getUserId(accessToken);
+
+        return ResponseEntity.ok().body(
+                UserInfoResponseDto.fromEntity(userService.exchange(Long.parseLong(userId), userExchangeRequestDto))
+        );
     }
 
 }

--- a/src/main/java/com/example/holing/bounded_context/user/dto/UserExchangeRequestDto.java
+++ b/src/main/java/com/example/holing/bounded_context/user/dto/UserExchangeRequestDto.java
@@ -1,0 +1,8 @@
+package com.example.holing.bounded_context.user.dto;
+
+import lombok.Getter;
+
+@Getter
+public class UserExchangeRequestDto {
+    int productPrice;
+}

--- a/src/main/java/com/example/holing/bounded_context/user/exception/UserExceptionCode.java
+++ b/src/main/java/com/example/holing/bounded_context/user/exception/UserExceptionCode.java
@@ -9,7 +9,9 @@ public enum UserExceptionCode implements ExceptionCode {
     TARGET_NOT_FOUND(HttpStatus.NOT_FOUND, "대상자를 찾을 수 없습니다."),
     MATE_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자의 짝꿍을 찾을 수 없습니다."),
     USER_MATE_EXISTS(HttpStatus.CONFLICT, "사용자의 짝꿍이 이미 존재합니다."),
-    TARGET_MATE_EXISTS(HttpStatus.CONFLICT, "대상자의 짝꿍이 이미 존재합니다.");
+    TARGET_MATE_EXISTS(HttpStatus.CONFLICT, "대상자의 짝꿍이 이미 존재합니다."),
+    LACK_OF_POINT(HttpStatus.BAD_REQUEST, "포인트가 부족합니다.");
+
 
     HttpStatus httpStatus;
     String cause;

--- a/src/main/java/com/example/holing/bounded_context/user/service/UserService.java
+++ b/src/main/java/com/example/holing/bounded_context/user/service/UserService.java
@@ -1,6 +1,7 @@
 package com.example.holing.bounded_context.user.service;
 
 import com.example.holing.base.exception.GlobalException;
+import com.example.holing.bounded_context.user.dto.UserExchangeRequestDto;
 import com.example.holing.bounded_context.user.entity.User;
 import com.example.holing.bounded_context.user.exception.UserExceptionCode;
 import com.example.holing.bounded_context.user.repository.UserRepository;
@@ -60,5 +61,19 @@ public class UserService {
     @Transactional
     public void delete(User user) {
         userRepository.delete(user);
+    }
+
+    @Transactional
+    public User exchange(Long userId, UserExchangeRequestDto userExchangeRequestDto) {
+        User user = read(userId);
+
+        int productPrice = userExchangeRequestDto.getProductPrice();
+        if (user.getPoint() < productPrice) {
+            throw new GlobalException(UserExceptionCode.LACK_OF_POINT);
+        } else {
+            user.addPoint(-productPrice);
+        }
+
+        return user;
     }
 }


### PR DESCRIPTION
### 🔥 작업 동기 및 이슈

- close: #83 
- 마이페이지에서 상품에 대해서 교환하기 API를 구현

### 🛠️ 변경 사항

- 기존 사용자 관련 Swagger에 상품 교환 API 추가
- 포인트가 부족할 경우, 포인트가 부족하다는 Custom Exception 추가

### ☑️ 테스트 결과

- 포인트 부족한 경우
   ![image](https://github.com/user-attachments/assets/745673ee-34f3-4c3b-b610-0a95947d1801)

- 교환 완료 (기존의 UserInfoResponseDto를 반환)
  ![image](https://github.com/user-attachments/assets/b080bb33-cec7-419f-b246-4a4f69683ec0)



### 🌟 참고사항

- 엔티티 변환이 필요한 Dto는 아니라고 판단되어 record가 아닌 클래스로 구현하였습니다!
- 기존의 UserInfoResponseDto를 반환하는 이유는 사용자의 nickname, point를 반환해야하는데 새로운 Dto를 만드는 것보다는 기존의 dto를 활용하는 것이 좋다고 생각했습니다 :)