### PR TITLE
feat: User Entity 자가 진단 테스트 유무 필드 추가 및 관련 API 구현

### DIFF
--- a/src/main/java/com/example/holing/bounded_context/user/api/UserApi.java
+++ b/src/main/java/com/example/holing/bounded_context/user/api/UserApi.java
@@ -151,4 +151,9 @@ public interface UserApi {
                     })),
     })
     ResponseEntity<UserInfoResponseDto> exchange(HttpServletRequest request, @RequestBody UserExchangeRequestDto userExchangeRequestDto);
+
+    @PatchMapping("/self-test")
+    @Operation(summary = "유저 자가 테스트 완료 처리", description = "로그인 한 사용자의 자가 진단 테스트 유무를 완료 처리하는 API 입니다.")
+    @ApiResponse(responseCode = "200", description = "자가 진단 테스트 완료")
+    ResponseEntity<UserInfoResponseDto> completeSelfTest(HttpServletRequest request);
 }

--- a/src/main/java/com/example/holing/bounded_context/user/controller/UserController.java
+++ b/src/main/java/com/example/holing/bounded_context/user/controller/UserController.java
@@ -111,4 +111,12 @@ public class UserController implements UserApi {
         );
     }
 
+    public ResponseEntity<UserInfoResponseDto> completeSelfTest(HttpServletRequest request) {
+        String accessToken = jwtProvider.getToken(request);
+        String userId = jwtProvider.getUserId(accessToken);
+
+        return ResponseEntity.ok().body(
+                UserInfoResponseDto.fromEntity(userService.completeSelfTest(Long.parseLong(userId)))
+        );
+    }
 }

--- a/src/main/java/com/example/holing/bounded_context/user/dto/UserInfoResponseDto.java
+++ b/src/main/java/com/example/holing/bounded_context/user/dto/UserInfoResponseDto.java
@@ -25,7 +25,9 @@ public record UserInfoResponseDto(
         @Schema(description = "소셜 ID", example = "1234567890")
         Long socialId,
         @Schema(description = "짝꿍 닉네임", example = "mateNickname")
-        String mateNickname
+        String mateNickname,
+        @Schema(description = "자가 진단 테스트 유무", example = "true")
+        boolean isSelfTested
 ) {
     public static UserInfoResponseDto fromEntity(User user) {
         return new UserInfoResponseDto(
@@ -39,7 +41,8 @@ public record UserInfoResponseDto(
                 user.getSocialId(),
                 Optional.ofNullable(user.getMate())
                         .map(User::getNickname)
-                        .orElse(null)
+                        .orElse(null),
+                user.getIsSelfTested()
         );
     }
 }

--- a/src/main/java/com/example/holing/bounded_context/user/entity/User.java
+++ b/src/main/java/com/example/holing/bounded_context/user/entity/User.java
@@ -62,6 +62,9 @@ public class User extends BaseTimeEntity implements UserDetails {
     @Column(nullable = false)
     private Boolean isChanged;
 
+    @Column(nullable = false)
+    private Boolean isSelfTested;
+
     @OneToOne
     private User mate;
 
@@ -79,6 +82,7 @@ public class User extends BaseTimeEntity implements UserDetails {
         this.point = 0;
         this.socialId = socialId;
         this.isChanged = false;
+        this.isSelfTested = false;
     }
 
     public static User of(OAuthUserInfoDto dto, SignInRequestDto request) {
@@ -150,6 +154,10 @@ public class User extends BaseTimeEntity implements UserDetails {
 
     public void setIsChanged(boolean state) {
         this.isChanged = state;
+    }
+
+    public void setIsSelfTested(boolean isSelfTested) {
+        this.isSelfTested = isSelfTested;
     }
 
 }

--- a/src/main/java/com/example/holing/bounded_context/user/service/UserService.java
+++ b/src/main/java/com/example/holing/bounded_context/user/service/UserService.java
@@ -76,4 +76,12 @@ public class UserService {
 
         return user;
     }
+
+    @Transactional
+    public User completeSelfTest(Long userId) {
+        User user = read(userId);
+        user.setIsSelfTested(true);
+
+        return user;
+    }
 }


### PR DESCRIPTION
### 🔥 작업 동기 및 이슈

- close: #85 
- API URL 경로: [PATCH] /user/self-test

### 🛠️ 변경 사항

- 기존의 User Entity에 isSelfTested 라는 필드 추가
  - 사용자의 자가 진단 테스트 확인을 위한 필드
- 관련 메소드로 User Entity 내의 setIsSelfTested 메소드 추가 및 UserInfoResponseDto에도 해당 필드 추가
- 자가 진단 테스트 완료 처리를 위한 API 구현
- Swagger에 추가, Custom Exception은 별도 구현 X
  - 로그인 후 사용자 정보 조회 API 요청 → 해당 필드가 false 일 경우 자가 진단 테스트, true 일 경우 홈 화면으로 이동
  - 위의 기능 흐름을 봤을 때, 별도의 에러 처리는 필요가 없을 것 같다고 판단되었습니다!

### ☑️ 테스트 결과

- 사용자 정보 조회 시 해당 필드가 추가되어 전달됨. 
  ![image](https://github.com/user-attachments/assets/4c16d04f-169c-427b-b678-534642df1259)


### 🌟 참고사항

- X