### PR TITLE
Report 예외 추가 및 반환값 수정

### DIFF
--- a/src/main/java/com/example/holing/bounded_context/report/api/ReportApi.java
+++ b/src/main/java/com/example/holing/bounded_context/report/api/ReportApi.java
@@ -28,6 +28,15 @@ public interface ReportApi {
             기록이 없는 경우 빈 객체가 반환됩니다.
             """)
     @ApiResponse(responseCode = "200", description = "본인 증상 테스트 기록 점수 조회 성공")
+    @ApiResponse(responseCode = "404", description = "본인의 증상 테스트 기록이 존재하지 않는 경우",
+            content = @Content(mediaType = "application/json", examples = {
+                    @ExampleObject(value = """
+                                                                        {
+                                                                            "timestamp": "2024-07-19T17:56:39.188+00:00",
+                                                                            "name": "TEST_HISTORY_NOT_FOUND_BY_USER",
+                                                                            "cause": "해당 유저의 증상 테스트 기록이 존재하지 않습니다."
+                                                                        }
+                            """)}))
     ResponseEntity<List<UserReportScoreResponseDto>> score(HttpServletRequest request);
 
     @GetMapping("/user/mate/reports/score")
@@ -38,15 +47,22 @@ public interface ReportApi {
             """)
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "짝꿍 증상 테스트 기록 점수 조회 성공"),
-            @ApiResponse(responseCode = "404", description = "짝꿍이 존재하지 않는 경우",
+            @ApiResponse(responseCode = "404", description = "짝꿍 또는 짝꿍의 증상 테스트 기록이 존재하지 않는 경우",
                     content = @Content(mediaType = "application/json", examples = {
-                            @ExampleObject(value = """
+                            @ExampleObject(name = "MATE_NOT_FOUND", value = """
                                                                                 {
                                                                                     "timestamp": "2024-07-19T17:56:39.188+00:00",
                                                                                     "name": "MATE_NOT_FOUND",
                                                                                     "cause": "사용자의 짝꿍을 찾을 수 없습니다."
                                                                                 }
                                     """),
+                            @ExampleObject(name = "TEST_HISTORY_NOT_FOUND_BY_USER", value = """
+                                                                                {
+                                                                                    "timestamp": "2024-07-19T17:56:39.188+00:00",
+                                                                                    "name": "TEST_HISTORY_NOT_FOUND_BY_USER",
+                                                                                    "cause": "해당 유저의 증상 테스트 기록이 존재하지 않습니다."
+                                                                                }
+                                    """)
                     }))
     })
     ResponseEntity<List<UserReportScoreResponseDto>> mateScore(HttpServletRequest request);
@@ -58,6 +74,15 @@ public interface ReportApi {
             기록이 없는 경우 빈 객체가 반환됩니다.
             """)
     @ApiResponse(responseCode = "200", description = "본인 증상 테스트 기록 요약 조회 성공")
+    @ApiResponse(responseCode = "404", description = "본인의 증상 테스트 기록이 존재하지 않는 경우",
+            content = @Content(mediaType = "application/json", examples = {
+                    @ExampleObject(value = """
+                                                                        {
+                                                                            "timestamp": "2024-07-19T17:56:39.188+00:00",
+                                                                            "name": "TEST_HISTORY_NOT_FOUND_BY_USER",
+                                                                            "cause": "해당 유저의 증상 테스트 기록이 존재하지 않습니다."
+                                                                        }
+                            """)}))
     ResponseEntity<List<UserReportSummaryResponseDto>> summary(HttpServletRequest request);
 
     @GetMapping("/user/mate/reports/summary")
@@ -68,13 +93,20 @@ public interface ReportApi {
             """)
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "짝꿍 증상 테스트 기록 요약 조회 성공"),
-            @ApiResponse(responseCode = "404", description = "짝꿍이 존재하지 않는 경우",
+            @ApiResponse(responseCode = "404", description = "짝꿍 또는 짝꿍의 증상 테스트 기록이 존재하지 않는 경우",
                     content = @Content(mediaType = "application/json", examples = {
-                            @ExampleObject(value = """
+                            @ExampleObject(name = "MATE_NOT_FOUND", value = """
                                                                                 {
                                                                                     "timestamp": "2024-07-19T17:56:39.188+00:00",
                                                                                     "name": "MATE_NOT_FOUND",
                                                                                     "cause": "사용자의 짝꿍을 찾을 수 없습니다."
+                                                                                }
+                                    """),
+                            @ExampleObject(name = "TEST_HISTORY_NOT_FOUND_BY_USER", value = """
+                                                                                {
+                                                                                    "timestamp": "2024-07-19T17:56:39.188+00:00",
+                                                                                    "name": "TEST_HISTORY_NOT_FOUND_BY_USER",
+                                                                                    "cause": "해당 유저의 증상 테스트 기록이 존재하지 않습니다."
                                                                                 }
                                     """),
                     }))

--- a/src/main/java/com/example/holing/bounded_context/report/controller/ReportController.java
+++ b/src/main/java/com/example/holing/bounded_context/report/controller/ReportController.java
@@ -39,7 +39,8 @@ public class ReportController implements ReportApi {
         String userId = jwtProvider.getUserId(accessToken);
 
         List<UserReport> reports = userReportService.readScore(Long.parseLong(userId));
-        List<UserReportScoreResponseDto> response = reports.stream().map(UserReportScoreResponseDto::fromEntity).toList();
+        List<UserReportScoreResponseDto> response = reports.stream()
+                .map(UserReportScoreResponseDto::fromEntity).toList();
         return ResponseEntity.ok().body(response);
     }
 
@@ -51,7 +52,8 @@ public class ReportController implements ReportApi {
         if (user.getMate() == null) throw new GlobalException(UserExceptionCode.MATE_NOT_FOUND);
 
         List<UserReport> reports = userReportService.readScore(user.getMate().getId());
-        List<UserReportScoreResponseDto> response = reports.stream().map(UserReportScoreResponseDto::fromEntity).toList();
+        List<UserReportScoreResponseDto> response = reports.stream()
+                .map(UserReportScoreResponseDto::fromEntity).toList();
         return ResponseEntity.ok().body(response);
     }
 
@@ -59,7 +61,8 @@ public class ReportController implements ReportApi {
         String accessToken = jwtProvider.getToken(request);
         String userId = jwtProvider.getUserId(accessToken);
 
-        List<UserReportSummaryResponseDto> response = userReportService.readSummary(Long.parseLong(userId)).stream()
+        List<UserReport> reports = userReportService.readSummary(Long.parseLong(userId));
+        List<UserReportSummaryResponseDto> response = reports.stream()
                 .map(UserReportSummaryResponseDto::fromEntity).toList();
         return ResponseEntity.ok().body(response);
     }
@@ -71,7 +74,8 @@ public class ReportController implements ReportApi {
         User user = userService.read(Long.parseLong(userId));
         if (user.getMate() == null) throw new GlobalException(UserExceptionCode.MATE_NOT_FOUND);
 
-        List<UserReportSummaryResponseDto> response = userReportService.readSummary(user.getMate().getId()).stream()
+        List<UserReport> reports = userReportService.readSummary(user.getMate().getId());
+        List<UserReportSummaryResponseDto> response = reports.stream()
                 .map(UserReportSummaryResponseDto::fromEntity).toList();
         return ResponseEntity.ok().body(response);
     }

--- a/src/main/java/com/example/holing/bounded_context/report/exception/ReportExceptionCode.java
+++ b/src/main/java/com/example/holing/bounded_context/report/exception/ReportExceptionCode.java
@@ -7,7 +7,7 @@ public enum ReportExceptionCode implements ExceptionCode {
     TEST_HISTORY_NOT_FOUND_BY_ID(HttpStatus.NOT_FOUND, "해당 증상 테스트 기록이 존재하지 않습니다."),
     ACCESS_DENIED_TO_TEST_HISTORY(HttpStatus.FORBIDDEN, "해당 증상 테스트 기록에 접근 권한이 없습니다."),
     USER_REPORT_PERIOD_NOT_MET(HttpStatus.BAD_REQUEST, "마지막 증상 테스트 이후 7일이 경과해야 합니다."),
-    TEST_HISTORY_NOT_FOUND_BY_USER(HttpStatus.BAD_REQUEST, "해당 유저의 증상 테스트 기록이 존재하지 않습니다.");
+    TEST_HISTORY_NOT_FOUND_BY_USER(HttpStatus.NOT_FOUND, "해당 유저의 증상 테스트 기록이 존재하지 않습니다.");
 
     HttpStatus httpStatus;
     String cause;

--- a/src/main/java/com/example/holing/bounded_context/report/exception/ReportExceptionCode.java
+++ b/src/main/java/com/example/holing/bounded_context/report/exception/ReportExceptionCode.java
@@ -6,7 +6,8 @@ import org.springframework.http.HttpStatus;
 public enum ReportExceptionCode implements ExceptionCode {
     TEST_HISTORY_NOT_FOUND_BY_ID(HttpStatus.NOT_FOUND, "해당 증상 테스트 기록이 존재하지 않습니다."),
     ACCESS_DENIED_TO_TEST_HISTORY(HttpStatus.FORBIDDEN, "해당 증상 테스트 기록에 접근 권한이 없습니다."),
-    USER_REPORT_PERIOD_NOT_MET(HttpStatus.BAD_REQUEST, "마지막 증상 테스트 이후 7일이 경과해야 합니다.");
+    USER_REPORT_PERIOD_NOT_MET(HttpStatus.BAD_REQUEST, "마지막 증상 테스트 이후 7일이 경과해야 합니다."),
+    TEST_HISTORY_NOT_FOUND_BY_USER(HttpStatus.BAD_REQUEST, "해당 유저의 증상 테스트 기록이 존재하지 않습니다.");
 
     HttpStatus httpStatus;
     String cause;

--- a/src/main/java/com/example/holing/bounded_context/report/repository/UserReportRepository.java
+++ b/src/main/java/com/example/holing/bounded_context/report/repository/UserReportRepository.java
@@ -57,8 +57,7 @@ public interface UserReportRepository extends JpaRepository<UserReport, Long> {
      */
     @Query("select ur from UserReport ur " +
             "join fetch ur.reports r " +
-            "where ur.user.id = :userId " +
-            "order by ur.createdAt asc"
+            "where ur.user.id = :userId "
     )
-    List<UserReport> findAllWithReportByUser(Long userId);
+    List<UserReport> findAllWithReportByUser(Long userId, Pageable pageable);
 }

--- a/src/main/java/com/example/holing/bounded_context/report/service/UserReportService.java
+++ b/src/main/java/com/example/holing/bounded_context/report/service/UserReportService.java
@@ -32,12 +32,19 @@ public class UserReportService {
     }
 
     public List<UserReport> readScore(Long userId) {
-        return userReportRepository.findAllWithReportByUser(userId);
+        Pageable pageable = PageRequest.of(0, 5, Sort.by(Sort.Direction.DESC, "createdAt"));
+        List<UserReport> allWithReportByUser = userReportRepository.findAllWithReportByUser(userId, pageable);
+        if (allWithReportByUser.isEmpty())
+            throw new GlobalException(ReportExceptionCode.TEST_HISTORY_NOT_FOUND_BY_USER);
+        return allWithReportByUser;
     }
 
     public List<UserReport> readSummary(Long userId) {
         Pageable pageable = PageRequest.of(0, 4, Sort.by(Sort.Direction.DESC, "createdAt"));
-        return userReportRepository.findTop4WithReportAndSolutionByUser(userId, pageable);
+        List<UserReport> top4WithReportAndSolutionByUser = userReportRepository.findTop4WithReportAndSolutionByUser(userId, pageable);
+        if (top4WithReportAndSolutionByUser.isEmpty())
+            throw new GlobalException(ReportExceptionCode.TEST_HISTORY_NOT_FOUND_BY_USER);
+        return top4WithReportAndSolutionByUser;
     }
 
     public UserReport readDetail(User user, Long id) {


### PR DESCRIPTION
### 🔥 작업 동기 및 이슈

- close: #88 
- close: #89 
- close: #90 

### 🛠️ 변경 사항

- 리포트 요약 조회 / 리포트 점수 조회 시 리포트가 없는 경우 예외 추가
- 리포트 점수 조회 시 최근 5개를 반환하도록 수정
- API 명세서 수정

### ☑️ 테스트 결과

<details>
<summary>본인 리포트 점수 조회</summary>

- 성공 : 본인 리포트가 있는 경우 (최근 5개 조회)
    <img width="786" alt="image" src="https://github.com/user-attachments/assets/1c8a92a2-f6d1-4578-ace1-22c3e54a2506">

- 실패 : 본인 리포트가 없는 경우
    <img width="786" alt="image" src="https://github.com/user-attachments/assets/69c1d67f-b870-422f-af5f-4b680b419e7d">

</details>

<details>
<summary>짝꿍 리포트 점수 조회</summary>

- 짝꿍 리포트 점수 조회 : 본인 리포트가 있는 경우 (최근 5개 조회)
    <img width="786" alt="image" src="https://github.com/user-attachments/assets/885d8cbe-8412-4f38-a8e8-edbf0f2030fd">

- 짝꿍 리포트 점수 조회 : 짝꿍 리포트가 없는 경우
    <img width="786" alt="image" src="https://github.com/user-attachments/assets/b63d5b65-2460-41fe-aad6-0d97f4f18e06">

</details>

<details>
<summary>본인 리포트 요약 조회</summary>

- 본인 리포트 요약 조회 : 본인 리포트가 없는 경우
    <img width="786" alt="image" src="https://github.com/user-attachments/assets/aac3fb89-7d7f-4021-89e7-3610d3239cb5">

</details>

<details>
<summary>짝꿍  리포트 요약 조회</summary>

- 짝꿍 리포트 요약 조회 : 짝꿍 리포트가 없는 경우
     <img width="786" alt="image" src="https://github.com/user-attachments/assets/51d84d67-324c-4ed2-bab9-72620c8c33ea">

</details>

### 🌟 참고사항

- 