### PR TITLE
medicine 예외 추가 및 명세서 작성

### DIFF
--- a/src/main/java/com/example/holing/bounded_context/medicine/api/MedicineApi.java
+++ b/src/main/java/com/example/holing/bounded_context/medicine/api/MedicineApi.java
@@ -1,7 +1,11 @@
 package com.example.holing.bounded_context.medicine.api;
 
 import com.example.holing.bounded_context.medicine.dto.MedicineRequestDto;
+import com.example.holing.bounded_context.medicine.dto.MedicineResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
@@ -12,6 +16,8 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.util.List;
 
 @Tag(name = "[영양제 관련 API]", description = "영양제 조회, 생성 및 기록 변경 API")
 @RequestMapping("/user/medicines")
@@ -25,13 +31,56 @@ public interface MedicineApi {
             사용자가 영양제 목록을 조회하기 위한 API 입니다.
             영양제 복용 기록을 통해 상태를 설정합니다.
             """)
-    public ResponseEntity<?> read(HttpServletRequest request);
+    @ApiResponse(responseCode = "200", description = "영양제 목록 조회 성공")
+    ResponseEntity<List<MedicineResponseDto>> read(HttpServletRequest request);
 
     @PostMapping("/{medicineId}")
     @Operation(summary = "영양제 복용 기록 생성", description = "사용자가 영양제를 복용했다는 기록을 생성하기 위한 API 입니다.")
-    public ResponseEntity<String> taken(HttpServletRequest request, @PathVariable Long medicineId);
+    @ApiResponse(responseCode = "200", description = "영양제 복용 기록 생성 성공")
+    @ApiResponse(responseCode = "403", description = "해당 영양제의 작성자가 아닌 경우",
+            content = @Content(mediaType = "application/json", examples = {
+                    @ExampleObject(value = """
+                                                                        {
+                                                                            "timestamp": "2024-07-19T17:56:39.188+00:00",
+                                                                            "name": "ACCESS_DENIED_TO_MEDICINE",
+                                                                            "cause": "해당 영양제에 접근 권한이 없습니다."
+                                                                        }
+                            """),
+            }))
+    @ApiResponse(responseCode = "404", description = "영양제가 존재하지 않는 경우",
+            content = @Content(mediaType = "application/json", examples = {
+                    @ExampleObject(value = """
+                                                                        {
+                                                                            "timestamp": "2024-07-19T17:56:39.188+00:00",
+                                                                            "name": "MEDICINE_NOT_FOUND",
+                                                                            "cause": "해당 영양제가 존재하지 않습니다."
+                                                                        }
+                            """),
+            }))
+    ResponseEntity<String> taken(HttpServletRequest request, @PathVariable Long medicineId);
 
     @DeleteMapping("/{medicineId}")
     @Operation(summary = "영양제 복용 기록 삭제", description = "사용자가 영양제 복용으로 생성된 영양제 복용 기록을 삭제하기 위한 API 입니다.")
-    public ResponseEntity<String> skip(HttpServletRequest request, @PathVariable Long medicineId);
+    @ApiResponse(responseCode = "200", description = "영양제 복용 기록 삭제 성공")
+    @ApiResponse(responseCode = "403", description = "해당 영양제의 작성자가 아닌 경우",
+            content = @Content(mediaType = "application/json", examples = {
+                    @ExampleObject(value = """
+                                                                        {
+                                                                            "timestamp": "2024-07-19T17:56:39.188+00:00",
+                                                                            "name": "ACCESS_DENIED_TO_MEDICINE",
+                                                                            "cause": "해당 영양제에 접근 권한이 없습니다."
+                                                                        }
+                            """),
+            }))
+    @ApiResponse(responseCode = "404", description = "영양제가 존재하지 않는 경우",
+            content = @Content(mediaType = "application/json", examples = {
+                    @ExampleObject(value = """
+                                                                        {
+                                                                            "timestamp": "2024-07-19T17:56:39.188+00:00",
+                                                                            "name": "MEDICINE_NOT_FOUND",
+                                                                            "cause": "해당 영양제가 존재하지 않습니다."
+                                                                        }
+                            """),
+            }))
+    ResponseEntity<String> skip(HttpServletRequest request, @PathVariable Long medicineId);
 }

--- a/src/main/java/com/example/holing/bounded_context/medicine/controller/MedicineController.java
+++ b/src/main/java/com/example/holing/bounded_context/medicine/controller/MedicineController.java
@@ -1,10 +1,12 @@
 package com.example.holing.bounded_context.medicine.controller;
 
+import com.example.holing.base.exception.GlobalException;
 import com.example.holing.base.jwt.JwtProvider;
 import com.example.holing.bounded_context.medicine.api.MedicineApi;
 import com.example.holing.bounded_context.medicine.dto.MedicineRequestDto;
 import com.example.holing.bounded_context.medicine.dto.MedicineResponseDto;
 import com.example.holing.bounded_context.medicine.entity.Medicine;
+import com.example.holing.bounded_context.medicine.exception.MedicineExceptionCode;
 import com.example.holing.bounded_context.medicine.serivce.MedicineHistoryService;
 import com.example.holing.bounded_context.medicine.serivce.MedicineService;
 import com.example.holing.bounded_context.user.entity.User;
@@ -42,10 +44,9 @@ public class MedicineController implements MedicineApi {
         String accessToken = jwtProvider.getToken(request);
         String userId = jwtProvider.getUserId(accessToken);
 
-        User user = userService.read(Long.parseLong(userId));
-
-        List<Medicine> medicines = medicineService.readAll(user);
-        List<MedicineResponseDto> response = medicines.stream().map(MedicineResponseDto::fromEntity).toList();
+        List<Object[]> medicines = medicineService.readAll(Long.parseLong(userId));
+        List<MedicineResponseDto> response = medicines.stream()
+                .map(MedicineResponseDto::fromEntity).toList();
         return ResponseEntity.ok().body(response);
     }
 
@@ -53,7 +54,9 @@ public class MedicineController implements MedicineApi {
         String accessToken = jwtProvider.getToken(request);
         String userId = jwtProvider.getUserId(accessToken);
 
-        User user = userService.read(Long.parseLong(userId));
+        Medicine medicine = medicineService.readById(medicineId);
+        if (medicine.getUser().getId() != Long.parseLong(userId))
+            throw new GlobalException(MedicineExceptionCode.ACCESS_DENIED_TO_MEDICINE);
         medicineHistoryService.taken(medicineId);
         return ResponseEntity.ok("약 복용 기록이 저장되었습니다.");
     }
@@ -62,7 +65,9 @@ public class MedicineController implements MedicineApi {
         String accessToken = jwtProvider.getToken(request);
         String userId = jwtProvider.getUserId(accessToken);
 
-        User user = userService.read(Long.parseLong(userId));
+        Medicine medicine = medicineService.readById(medicineId);
+        if (medicine.getUser().getId() != Long.parseLong(userId))
+            throw new GlobalException(MedicineExceptionCode.ACCESS_DENIED_TO_MEDICINE);
         medicineHistoryService.skip(medicineId);
         return ResponseEntity.ok("약 복용 기록이 삭제되었습니다.");
     }

--- a/src/main/java/com/example/holing/bounded_context/medicine/controller/MedicineController.java
+++ b/src/main/java/com/example/holing/bounded_context/medicine/controller/MedicineController.java
@@ -40,7 +40,7 @@ public class MedicineController implements MedicineApi {
         return ResponseEntity.ok().body("약이 성공적으로 생성되었습니다.");
     }
 
-    public ResponseEntity<?> read(HttpServletRequest request) {
+    public ResponseEntity<List<MedicineResponseDto>> read(HttpServletRequest request) {
         String accessToken = jwtProvider.getToken(request);
         String userId = jwtProvider.getUserId(accessToken);
 

--- a/src/main/java/com/example/holing/bounded_context/medicine/dto/MedicineResponseDto.java
+++ b/src/main/java/com/example/holing/bounded_context/medicine/dto/MedicineResponseDto.java
@@ -1,11 +1,7 @@
 package com.example.holing.bounded_context.medicine.dto;
 
-import com.example.holing.bounded_context.medicine.entity.Medicine;
-import com.example.holing.bounded_context.medicine.entity.MedicineHistory;
-
-import java.time.LocalDate;
+import java.sql.Time;
 import java.time.LocalTime;
-import java.util.Optional;
 
 public record MedicineResponseDto(
         Long id,
@@ -13,15 +9,12 @@ public record MedicineResponseDto(
         LocalTime takenAt,
         Boolean isTaken
 ) {
-    public static MedicineResponseDto fromEntity(Medicine medicine) {
-        Optional<MedicineHistory> recentHistory = medicine.getMedicineHistoryList().stream().findFirst();
-
+    public static MedicineResponseDto fromEntity(Object[] objects) {
         return new MedicineResponseDto(
-                medicine.getId(),
-                medicine.getName(),
-                medicine.getTakenAt(),
-                recentHistory.isPresent() &&
-                        LocalDate.now().equals(recentHistory.get().getCreatedAt().toLocalDate())
+                (Long) objects[0],
+                (String) objects[1],
+                ((Time) objects[2]).toLocalTime(),
+                (Long) objects[4] != null
         );
     }
 }

--- a/src/main/java/com/example/holing/bounded_context/medicine/dto/MedicineResponseDto.java
+++ b/src/main/java/com/example/holing/bounded_context/medicine/dto/MedicineResponseDto.java
@@ -1,12 +1,18 @@
 package com.example.holing.bounded_context.medicine.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.sql.Time;
 import java.time.LocalTime;
 
 public record MedicineResponseDto(
+        @Schema(description = "영양제 아이디", example = "1")
         Long id,
+        @Schema(description = "영양제 이름", example = "탁센")
         String name,
+        @Schema(description = "영양제 복용 시간", example = "16:00")
         LocalTime takenAt,
+        @Schema(description = "복용 유무", example = "true")
         Boolean isTaken
 ) {
     public static MedicineResponseDto fromEntity(Object[] objects) {

--- a/src/main/java/com/example/holing/bounded_context/medicine/exception/MedicineExceptionCode.java
+++ b/src/main/java/com/example/holing/bounded_context/medicine/exception/MedicineExceptionCode.java
@@ -1,0 +1,32 @@
+package com.example.holing.bounded_context.medicine.exception;
+
+import com.example.holing.base.exception.ExceptionCode;
+import org.springframework.http.HttpStatus;
+
+public enum MedicineExceptionCode implements ExceptionCode {
+    MEDICINE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 영양제가 존재하지 않습니다."),
+    ACCESS_DENIED_TO_MEDICINE(HttpStatus.FORBIDDEN, "해당 영양제에 접근 권한이 없습니다.");
+
+    HttpStatus httpStatus;
+    String cause;
+
+    MedicineExceptionCode(HttpStatus httpStatus, String cause) {
+        this.httpStatus = httpStatus;
+        this.cause = cause;
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String getCause() {
+        return cause;
+    }
+
+    @Override
+    public String getName() {
+        return name();
+    }
+}

--- a/src/main/java/com/example/holing/bounded_context/medicine/repository/MedicineHistoryRepository.java
+++ b/src/main/java/com/example/holing/bounded_context/medicine/repository/MedicineHistoryRepository.java
@@ -5,13 +5,12 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
-import java.time.LocalDateTime;
 import java.util.Optional;
 
 @Repository
 public interface MedicineHistoryRepository extends JpaRepository<MedicineHistory, Long> {
     @Query("select mh from MedicineHistory mh " +
             "where mh.medicine.id = :medicineId " +
-            "AND mh.createdAt BETWEEN :startOfDay AND :endOfDay")
-    Optional<MedicineHistory> findByMedicineAndCreatedAtToday(Long medicineId, LocalDateTime startOfDay, LocalDateTime endOfDay);
+            "AND DATE(mh.createdAt) = CURRENT_DATE")
+    Optional<MedicineHistory> findByMedicineAndCreatedAtToday(Long medicineId);
 }

--- a/src/main/java/com/example/holing/bounded_context/medicine/repository/MedicineRepository.java
+++ b/src/main/java/com/example/holing/bounded_context/medicine/repository/MedicineRepository.java
@@ -1,7 +1,6 @@
 package com.example.holing.bounded_context.medicine.repository;
 
 import com.example.holing.bounded_context.medicine.entity.Medicine;
-import com.example.holing.bounded_context.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
@@ -10,22 +9,9 @@ import java.util.List;
 
 @Repository
 public interface MedicineRepository extends JpaRepository<Medicine, Long> {
-
-    @Query("select m from Medicine m " +
-            "left join fetch m.medicineHistoryList " +
-            "where m.user = :user order by m.takenAt asc")
-    List<Medicine> findAllByUser(User user);
-
-//    @Query(value = "SELECT m.id, m.name, m.taken_at, mh.id " +
-//            "FROM medicine m " +
-//            "LEFT JOIN medicine_history mh ON m.id = mh.medicine_id " +
-//            "AND DATE(mh.created_at) = CURRENT_DATE " +
-//            "WHERE m.user_id = :userId", nativeQuery = true)
-//    List<Object[]> findAllByUserId(Long userId);
-
-
-//    @Query(value = "SELECT m.* FROM medicine m " +
-//            "LEFT JOIN medicine_history mh ON m.id = mh.medicine_id " +
-//            "AND DATE(mh.created_at) = CURRENT_DATE ", nativeQuery = true)
-//    List<Medicine> findAllByUserId(LocalDateTime startOfDay, LocalDateTime endOfDay);
+    @Query(value = "SELECT m.*, mh.id FROM medicine m " +
+            "LEFT JOIN medicine_history mh ON m.id = mh.medicine_id " +
+            "AND DATE(mh.created_at) = CURRENT_DATE " +
+            "WHERE m.user_id = :userId", nativeQuery = true)
+    List<Object[]> findAllByUserId(Long userId);
 }

--- a/src/main/java/com/example/holing/bounded_context/medicine/serivce/MedicineHistoryService.java
+++ b/src/main/java/com/example/holing/bounded_context/medicine/serivce/MedicineHistoryService.java
@@ -6,7 +6,6 @@ import com.example.holing.bounded_context.medicine.repository.MedicineHistoryRep
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Optional;
 
@@ -26,9 +25,7 @@ public class MedicineHistoryService {
     }
 
     public Optional<MedicineHistory> check(Long medicineId) {
-        LocalDateTime startOfDay = LocalDate.now().atStartOfDay();
-        LocalDateTime endOfDay = LocalDate.now().atTime(23, 59, 59);
-        return medicineHistoryRepository.findByMedicineAndCreatedAtToday(medicineId, startOfDay, endOfDay);
+        return medicineHistoryRepository.findByMedicineAndCreatedAtToday(medicineId);
     }
 
     public void taken(Long medicineId) {

--- a/src/main/java/com/example/holing/bounded_context/medicine/serivce/MedicineService.java
+++ b/src/main/java/com/example/holing/bounded_context/medicine/serivce/MedicineService.java
@@ -1,6 +1,8 @@
 package com.example.holing.bounded_context.medicine.serivce;
 
+import com.example.holing.base.exception.GlobalException;
 import com.example.holing.bounded_context.medicine.entity.Medicine;
+import com.example.holing.bounded_context.medicine.exception.MedicineExceptionCode;
 import com.example.holing.bounded_context.medicine.repository.MedicineRepository;
 import com.example.holing.bounded_context.user.entity.User;
 import lombok.RequiredArgsConstructor;
@@ -21,12 +23,12 @@ public class MedicineService {
         return medicineRepository.save(medicine);
     }
 
-    public List<Medicine> readAll(User user) {
-        return medicineRepository.findAllByUser(user);
+    public List<Object[]> readAll(Long userId) {
+        return medicineRepository.findAllByUserId(userId);
     }
-    
+
     public Medicine readById(Long medicineId) {
         return medicineRepository.findById(medicineId)
-                .orElseThrow(() -> new IllegalArgumentException("약이 존재하지 않습니다."));
+                .orElseThrow(() -> new GlobalException(MedicineExceptionCode.MEDICINE_NOT_FOUND));
     }
 }


### PR DESCRIPTION
### 🔥 작업 동기 및 이슈

- close: #

### 🛠️ 변경 사항

- 조회 쿼리 수정 : native query 를 사용한 Object[] 매핑
- 예외 추가 : 영양제가 없는 경우 / 접근권한이 없는 경우
- 명세서 작성

### ☑️ 테스트 결과 
<details>
<summary>영양제 복용 기록 생성 POST {{ip}}/user/medicines/{medicineId}</summary>

- 영양제의 생성자가 아닌 경우 
    <img width="786" alt="image" src="https://github.com/user-attachments/assets/ce8747db-5459-4f6b-83b3-745a33b82aeb">

- 영양제가 존재하지 않는 경우
    <img width="786" alt="image" src="https://github.com/user-attachments/assets/60d310ba-551f-46db-8767-a888cf3d6293">

</details>

<details>
<summary>영양제 복용 기록 삭제 DELETE {{ip}}/user/medicines/{medicineId}</summary>

- 영양제의 생성자가 아닌 경우 
    <img width="786" alt="image" src="https://github.com/user-attachments/assets/4b9059c8-cd45-4c1e-9b68-84eba859a74e">

- 영양제가 존재하지 않는 경우
    <img width="786" alt="image" src="https://github.com/user-attachments/assets/1f87bc74-641a-490b-bb2f-381fd3acf96a">

</details>



### 🌟 참고사항

- 데이터베이스의 날짜를 사용하는 쿼리의 경우 시간대를 맞춰야 한다.
- 네이티브 쿼리를 사용해서 Object 매핑을 사용해서 조회 쿼리를 줄인 것으로 생각되는데, 성능 차이는 얼마나 날지 모르겠다.