### PR TITLE
Medicine 삭제 API 구현

### DIFF
--- a/src/main/java/com/example/holing/bounded_context/medicine/api/MedicineApi.java
+++ b/src/main/java/com/example/holing/bounded_context/medicine/api/MedicineApi.java
@@ -34,7 +34,33 @@ public interface MedicineApi {
     @ApiResponse(responseCode = "200", description = "영양제 목록 조회 성공")
     ResponseEntity<List<MedicineResponseDto>> read(HttpServletRequest request);
 
-    @PostMapping("/{medicineId}")
+    @DeleteMapping("/{medicineId}")
+    @Operation(summary = "영양제 삭제", description = "사용자가 영양제를 삭제하기 위한 API 입니다.")
+    @ApiResponse(responseCode = "200", description = "영양제 삭제 성공")
+    @ApiResponse(responseCode = "403", description = "해당 영양제의 작성자가 아닌 경우",
+            content = @Content(mediaType = "application/json", examples = {
+                    @ExampleObject(value = """
+                                                                        {
+                                                                            "timestamp": "2024-07-19T17:56:39.188+00:00",
+                                                                            "name": "ACCESS_DENIED_TO_MEDICINE",
+                                                                            "cause": "해당 영양제에 접근 권한이 없습니다."
+                                                                        }
+                            """),
+            }))
+    @ApiResponse(responseCode = "404", description = "영양제가 존재하지 않는 경우",
+            content = @Content(mediaType = "application/json", examples = {
+                    @ExampleObject(value = """
+                                                                        {
+                                                                            "timestamp": "2024-07-19T17:56:39.188+00:00",
+                                                                            "name": "MEDICINE_NOT_FOUND",
+                                                                            "cause": "해당 영양제가 존재하지 않습니다."
+                                                                        }
+                            """),
+            }))
+    ResponseEntity<String> delete(HttpServletRequest request, @PathVariable Long medicineId);
+
+
+    @PostMapping("/{medicineId}/history")
     @Operation(summary = "영양제 복용 기록 생성", description = "사용자가 영양제를 복용했다는 기록을 생성하기 위한 API 입니다.")
     @ApiResponse(responseCode = "200", description = "영양제 복용 기록 생성 성공")
     @ApiResponse(responseCode = "403", description = "해당 영양제의 작성자가 아닌 경우",
@@ -59,7 +85,7 @@ public interface MedicineApi {
             }))
     ResponseEntity<String> taken(HttpServletRequest request, @PathVariable Long medicineId);
 
-    @DeleteMapping("/{medicineId}")
+    @DeleteMapping("/{medicineId}/history")
     @Operation(summary = "영양제 복용 기록 삭제", description = "사용자가 영양제 복용으로 생성된 영양제 복용 기록을 삭제하기 위한 API 입니다.")
     @ApiResponse(responseCode = "200", description = "영양제 복용 기록 삭제 성공")
     @ApiResponse(responseCode = "403", description = "해당 영양제의 작성자가 아닌 경우",

--- a/src/main/java/com/example/holing/bounded_context/medicine/controller/MedicineController.java
+++ b/src/main/java/com/example/holing/bounded_context/medicine/controller/MedicineController.java
@@ -37,7 +37,15 @@ public class MedicineController implements MedicineApi {
         User user = userService.read(Long.parseLong(userId));
 
         Medicine response = medicineService.create(user, MedicineRequestDto.toEntity(medicineRequestDto));
-        return ResponseEntity.ok().body("약이 성공적으로 생성되었습니다.");
+        return ResponseEntity.ok().body("영양제가 성공적으로 생성되었습니다.");
+    }
+
+    public ResponseEntity<String> delete(HttpServletRequest request, @PathVariable Long medicineId) {
+        String accessToken = jwtProvider.getToken(request);
+        String userId = jwtProvider.getUserId(accessToken);
+
+        Medicine response = medicineService.delete(Long.parseLong(userId), medicineId);
+        return ResponseEntity.ok().body("영양제가 성공적으로 삭제되었습니다.");
     }
 
     public ResponseEntity<List<MedicineResponseDto>> read(HttpServletRequest request) {
@@ -58,7 +66,7 @@ public class MedicineController implements MedicineApi {
         if (medicine.getUser().getId() != Long.parseLong(userId))
             throw new GlobalException(MedicineExceptionCode.ACCESS_DENIED_TO_MEDICINE);
         medicineHistoryService.taken(medicineId);
-        return ResponseEntity.ok("약 복용 기록이 저장되었습니다.");
+        return ResponseEntity.ok("영양제 복용 기록이 저장되었습니다.");
     }
 
     public ResponseEntity<String> skip(HttpServletRequest request, @PathVariable Long medicineId) {
@@ -69,6 +77,6 @@ public class MedicineController implements MedicineApi {
         if (medicine.getUser().getId() != Long.parseLong(userId))
             throw new GlobalException(MedicineExceptionCode.ACCESS_DENIED_TO_MEDICINE);
         medicineHistoryService.skip(medicineId);
-        return ResponseEntity.ok("약 복용 기록이 삭제되었습니다.");
+        return ResponseEntity.ok("영양제 복용 기록이 삭제되었습니다.");
     }
 }

--- a/src/main/java/com/example/holing/bounded_context/medicine/entity/Medicine.java
+++ b/src/main/java/com/example/holing/bounded_context/medicine/entity/Medicine.java
@@ -1,6 +1,7 @@
 package com.example.holing.bounded_context.medicine.entity;
 
 import com.example.holing.bounded_context.user.entity.User;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -37,7 +38,7 @@ public class Medicine {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    @OneToMany(fetch = FetchType.LAZY, mappedBy = "medicine")
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "medicine", cascade = CascadeType.REMOVE)
     private List<MedicineHistory> medicineHistoryList = new ArrayList<>();
 
     @Builder

--- a/src/main/java/com/example/holing/bounded_context/medicine/serivce/MedicineService.java
+++ b/src/main/java/com/example/holing/bounded_context/medicine/serivce/MedicineService.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
@@ -21,6 +22,15 @@ public class MedicineService {
     public Medicine create(User user, Medicine medicine) {
         medicine.setUser(user);
         return medicineRepository.save(medicine);
+    }
+
+    @Transactional
+    public Medicine delete(Long userId, Long medicineId) {
+        Medicine medicine = readById(medicineId);
+        if (!Objects.equals(medicine.getUser().getId(), userId))
+            throw new GlobalException(MedicineExceptionCode.ACCESS_DENIED_TO_MEDICINE);
+        medicineRepository.delete(medicine);
+        return medicine;
     }
 
     public List<Object[]> readAll(Long userId) {


### PR DESCRIPTION
### 🔥 작업 동기 및 이슈

- close: #

### 🛠️ 변경 사항

- 영양제 삭제 API 구현
- cascade 를 사용하여 삭제 시 영양제 복용 기록도 모두 삭제

### ☑️ 테스트 결과

- 영양제 삭제 성공
    <img width="953" alt="image" src="https://github.com/user-attachments/assets/de74b4f8-3738-47b0-b45a-06842c3bd261">

- 영양제 삭제 실패 : 403 - 영양제의 작성자가 아닌 경우
    <img width="953" alt="image" src="https://github.com/user-attachments/assets/0683ec26-6305-4334-9f59-b2ccb6bf7d2b">

- 영양제 삭제 실패 : 404 - 영양제가 존재하지 않는 경우 
    <img width="953" alt="image" src="https://github.com/user-attachments/assets/e8023608-de6e-4b01-bc71-9709a796de3e">


### 🌟 참고사항

- 